### PR TITLE
Add productivity page with UI, JS, and controller

### DIFF
--- a/src/main/java/com/example/telos/controller/ProductivityController.java
+++ b/src/main/java/com/example/telos/controller/ProductivityController.java
@@ -1,0 +1,14 @@
+package com.example.telos.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/productivity")
+public class ProductivityController {
+    @GetMapping
+    public String productivity() {
+        return "productivity";
+    }
+}

--- a/src/main/java/com/example/telos/security/SecurityConfig.java
+++ b/src/main/java/com/example/telos/security/SecurityConfig.java
@@ -27,6 +27,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/",
                                 "/login",
+                                "/productivity",
                                 "/about",
                                 "/helpus",
                                 "/css/**",

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1027,6 +1027,269 @@ a:focus {
     font-weight: 700;
 }
 
+/* ===== PRODUCTIVITY PAGE ===== */
+.productivity-shell {
+    max-width: 1080px;
+}
+
+.productivity-title {
+    max-width: none;
+}
+
+.productivity-lead {
+    max-width: 40rem;
+}
+
+.productivity-surface {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-lg);
+    width: 100%;
+    max-width: 860px;
+    margin: 0 auto;
+    padding: clamp(1.35rem, 2vw, 2rem);
+    border-radius: 1.55rem;
+    background:
+        linear-gradient(165deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
+        rgba(12, 12, 12, 0.58);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.productivity-tabs {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 1.5rem;
+    padding-bottom: 0.95rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.productivity-tab {
+    position: relative;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    font: inherit;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color var(--transition-fast), transform var(--transition-fast);
+}
+
+.productivity-tab::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -0.95rem;
+    height: 2px;
+    border-radius: 999px;
+    background: transparent;
+    transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.productivity-tab:hover,
+.productivity-tab:focus-visible {
+    color: var(--color-text);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.productivity-tab--active {
+    color: #fff1ea;
+}
+
+.productivity-tab--active::after {
+    background: linear-gradient(90deg, var(--color-primary-light), rgba(255, 255, 255, 0.25));
+}
+
+.productivity-panels {
+    display: flex;
+    flex-direction: column;
+}
+
+.productivity-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+    animation: fadeIn var(--transition-normal) ease-in;
+}
+
+.productivity-entry-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    padding: 1.35rem;
+    border-radius: 1.35rem;
+    background:
+        linear-gradient(170deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.015)),
+        rgba(16, 16, 16, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.22);
+}
+
+.productivity-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.productivity-input {
+    width: 100%;
+}
+
+.productivity-textarea {
+    resize: vertical;
+    min-height: 8.5rem;
+    line-height: 1.5;
+}
+
+.productivity-form-actions {
+    display: flex;
+    justify-content: flex-start;
+}
+
+.productivity-submit {
+    min-width: 140px;
+}
+
+.productivity-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.productivity-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding: 1rem 1.1rem;
+    border-radius: 1.2rem;
+    background:
+        linear-gradient(160deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.015)),
+        rgba(18, 18, 18, 0.72);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.productivity-item--note,
+.productivity-item--editing {
+    align-items: flex-start;
+}
+
+.productivity-item--editing {
+    border-color: rgba(231, 76, 60, 0.24);
+    box-shadow: inset 0 0 0 1px rgba(255, 107, 90, 0.08);
+}
+
+.productivity-check {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.85rem;
+    flex: 1;
+    min-width: 0;
+    cursor: pointer;
+}
+
+.productivity-check__input {
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+}
+
+.productivity-item__content {
+    color: var(--color-text);
+    word-break: break-word;
+}
+
+.productivity-item__content--completed {
+    color: rgba(255, 255, 255, 0.46);
+    text-decoration: line-through;
+}
+
+.productivity-item__editor {
+    flex: 1;
+    width: 100%;
+}
+
+.productivity-item__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    flex-shrink: 0;
+}
+
+.productivity-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--color-text-muted);
+    padding: 0.55rem 0.85rem;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color var(--transition-fast), color var(--transition-fast), background-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.productivity-action:hover,
+.productivity-action:focus-visible {
+    color: var(--color-text);
+    border-color: rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.08);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.productivity-action--primary {
+    color: #fff1ea;
+    border-color: rgba(231, 76, 60, 0.24);
+    background: rgba(231, 76, 60, 0.16);
+}
+
+.productivity-action--primary:hover,
+.productivity-action--primary:focus-visible {
+    border-color: rgba(255, 107, 90, 0.4);
+    background: rgba(231, 76, 60, 0.24);
+}
+
+.productivity-action--danger {
+    color: #ffc7bf;
+}
+
+.productivity-note {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.productivity-note__content {
+    color: var(--color-text);
+    word-break: break-word;
+}
+
+.productivity-note__meta {
+    color: rgba(255, 255, 255, 0.48);
+    font-size: var(--font-size-sm);
+}
+
+.productivity-empty-state {
+    padding: 1rem 1.1rem;
+    border-radius: 1.2rem;
+    border: 1px dashed rgba(255, 255, 255, 0.14);
+    background: rgba(255, 255, 255, 0.02);
+    color: rgba(255, 255, 255, 0.6);
+}
+
 /* ===== FOOTER ===== */
 .footer {
     padding: 0 0 1.1rem;
@@ -1139,6 +1402,25 @@ a:focus {
     .profile-entry__label {
         max-width: 5.5rem;
     }
+
+    .productivity-tabs {
+        gap: var(--spacing-md);
+    }
+
+    .productivity-item,
+    .productivity-item--note {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .productivity-form-actions,
+    .productivity-item__actions {
+        width: 100%;
+    }
+
+    .productivity-action {
+        flex: 1 1 0;
+    }
 }
 
 @media (max-width: 480px) {
@@ -1191,6 +1473,23 @@ a:focus {
 
     .mini-timer {
         width: 100%;
+    }
+
+    .productivity-entry-form,
+    .productivity-surface {
+        padding: 1.15rem;
+    }
+
+    .productivity-tabs {
+        gap: var(--spacing-sm);
+    }
+
+    .productivity-tab {
+        font-size: var(--font-size-sm);
+    }
+
+    .productivity-item {
+        padding: 0.9rem;
     }
 }
 

--- a/src/main/resources/static/js/productivity.js
+++ b/src/main/resources/static/js/productivity.js
@@ -1,0 +1,493 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const STORAGE_KEY = "telos.productivity.v1";
+    const DEFAULT_TAB = "todo";
+    const ITEM_TYPES = ["todo", "notes"];
+    const itemLabels = {
+        todo: "task",
+        notes: "note"
+    };
+    const inputIds = {
+        todo: "todoInput",
+        notes: "noteInput"
+    };
+    const inputNames = {
+        todo: "text",
+        notes: "content"
+    };
+    const dateFormatter = new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit"
+    });
+
+    const tabButtons = Array.from(document.querySelectorAll("[data-tab-trigger]"));
+    const panels = Array.from(document.querySelectorAll("[data-tab-panel]"));
+    const forms = Object.fromEntries(
+        ITEM_TYPES.map(type => [type, document.querySelector(`[data-entry-form="${type}"]`)])
+    );
+    const lists = Object.fromEntries(
+        ITEM_TYPES.map(type => [type, document.querySelector(`[data-item-list="${type}"]`)])
+    );
+    const emptyStates = Object.fromEntries(
+        ITEM_TYPES.map(type => [type, document.querySelector(`[data-empty-state="${type}"]`)])
+    );
+    const formMessages = Object.fromEntries(
+        ITEM_TYPES.map(type => [type, document.querySelector(`[data-form-message="${type}"]`)])
+    );
+
+    if (!tabButtons.length || !panels.length) return;
+
+    const storageAdapter = {
+        load() {
+            try {
+                const storedValue = window.localStorage.getItem(STORAGE_KEY);
+                if (!storedValue) {
+                    return this.emptyState();
+                }
+
+                const parsed = JSON.parse(storedValue);
+                return this.normalize(parsed);
+            } catch (error) {
+                return this.emptyState();
+            }
+        },
+        save(nextState) {
+            const normalizedState = this.normalize(nextState);
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizedState));
+            return normalizedState;
+        },
+        list(type) {
+            return this.load()[type];
+        },
+        create(type, payload) {
+            const state = this.load();
+            const now = new Date().toISOString();
+            const nextItem = {
+                id: createId(),
+                createdAt: now,
+                updatedAt: now,
+                ...payload
+            };
+
+            state[type] = [nextItem, ...state[type]];
+            return this.save(state)[type];
+        },
+        update(type, itemId, changes) {
+            const state = this.load();
+            state[type] = state[type].map(item => {
+                if (item.id !== itemId) return item;
+
+                return {
+                    ...item,
+                    ...changes,
+                    updatedAt: new Date().toISOString()
+                };
+            });
+
+            return this.save(state)[type];
+        },
+        delete(type, itemId) {
+            const state = this.load();
+            state[type] = state[type].filter(item => item.id !== itemId);
+            return this.save(state)[type];
+        },
+        emptyState() {
+            return {
+                todo: [],
+                notes: []
+            };
+        },
+        normalize(rawState) {
+            const safeState = this.emptyState();
+
+            safeState.todo = Array.isArray(rawState?.todo)
+                ? rawState.todo
+                    .filter(item => item && typeof item.id === "string" && typeof item.text === "string")
+                    .map(item => ({
+                        id: item.id,
+                        text: item.text,
+                        completed: Boolean(item.completed),
+                        createdAt: typeof item.createdAt === "string" ? item.createdAt : new Date().toISOString(),
+                        updatedAt: typeof item.updatedAt === "string" ? item.updatedAt : new Date().toISOString()
+                    }))
+                : [];
+
+            safeState.notes = Array.isArray(rawState?.notes)
+                ? rawState.notes
+                    .filter(item => item && typeof item.id === "string" && typeof item.content === "string")
+                    .map(item => ({
+                        id: item.id,
+                        content: item.content,
+                        createdAt: typeof item.createdAt === "string" ? item.createdAt : new Date().toISOString(),
+                        updatedAt: typeof item.updatedAt === "string" ? item.updatedAt : new Date().toISOString()
+                    }))
+                : [];
+
+            return safeState;
+        }
+    };
+
+    const state = {
+        activeTab: DEFAULT_TAB,
+        items: storageAdapter.load(),
+        editingByType: {
+            todo: null,
+            notes: null
+        }
+    };
+
+    function createId() {
+        if (window.crypto?.randomUUID) {
+            return window.crypto.randomUUID();
+        }
+
+        return `item-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    }
+
+    function escapeHtml(value) {
+        return String(value)
+            .replaceAll("&", "&amp;")
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;")
+            .replaceAll('"', "&quot;")
+            .replaceAll("'", "&#39;");
+    }
+
+    function formatTimestamp(value) {
+        return dateFormatter.format(new Date(value));
+    }
+
+    function syncStateFromStorage() {
+        state.items = storageAdapter.load();
+    }
+
+    function clearFormMessage(type) {
+        const messageElement = formMessages[type];
+        if (!messageElement) return;
+
+        messageElement.textContent = "";
+        messageElement.classList.add("hidden");
+        messageElement.classList.remove("form-message--error", "form-message--success");
+    }
+
+    function showFormMessage(type, message, isError = true) {
+        const messageElement = formMessages[type];
+        if (!messageElement) return;
+
+        messageElement.textContent = message;
+        messageElement.classList.remove("hidden");
+        messageElement.classList.toggle("form-message--error", isError);
+        messageElement.classList.toggle("form-message--success", !isError);
+    }
+
+    function focusPrimaryInput(type) {
+        document.getElementById(inputIds[type])?.focus();
+    }
+
+    function setActiveTab(nextTab) {
+        state.activeTab = nextTab;
+
+        tabButtons.forEach(button => {
+            const isActive = button.dataset.tabTrigger === nextTab;
+            button.classList.toggle("productivity-tab--active", isActive);
+            button.setAttribute("aria-selected", isActive ? "true" : "false");
+            button.tabIndex = isActive ? 0 : -1;
+        });
+
+        panels.forEach(panel => {
+            const isActive = panel.dataset.tabPanel === nextTab;
+            panel.classList.toggle("hidden", !isActive);
+            panel.setAttribute("aria-hidden", isActive ? "false" : "true");
+        });
+
+        focusPrimaryInput(nextTab);
+    }
+
+    function getTrimmedValue(type, container) {
+        const fieldName = inputNames[type];
+        const input = container.querySelector(`[name="${fieldName}"]`);
+        if (!input) return "";
+
+        return input.value.trim();
+    }
+
+    function markInvalid(input, shouldMark) {
+        if (!input) return;
+
+        if (shouldMark) {
+            input.setAttribute("aria-invalid", "true");
+            input.classList.add("settings-input--invalid");
+            return;
+        }
+
+        input.removeAttribute("aria-invalid");
+        input.classList.remove("settings-input--invalid");
+    }
+
+    function renderTodoItem(item) {
+        const isEditing = state.editingByType.todo === item.id;
+        const completedClass = item.completed ? " productivity-item__content--completed" : "";
+
+        if (isEditing) {
+            return `
+                <li class="productivity-item productivity-item--editing" data-item-id="${item.id}" data-item-type="todo">
+                    <div class="productivity-item__editor">
+                        <input
+                            class="settings-input productivity-input productivity-item__editor-input"
+                            data-edit-field="todo"
+                            name="text"
+                            type="text"
+                            maxlength="160"
+                            value="${escapeHtml(item.text)}"
+                        >
+                    </div>
+                    <div class="productivity-item__actions">
+                        <button class="productivity-action productivity-action--primary" type="button" data-action="save-edit">Save</button>
+                        <button class="productivity-action" type="button" data-action="cancel-edit">Cancel</button>
+                    </div>
+                </li>
+            `;
+        }
+
+        return `
+            <li class="productivity-item" data-item-id="${item.id}" data-item-type="todo">
+                <label class="productivity-check">
+                    <input
+                        class="settings-checkbox productivity-check__input"
+                        type="checkbox"
+                        data-action="toggle-complete"
+                        ${item.completed ? "checked" : ""}
+                    >
+                    <span class="productivity-item__content${completedClass}">${escapeHtml(item.text)}</span>
+                </label>
+                <div class="productivity-item__actions">
+                    <button class="productivity-action" type="button" data-action="edit">Edit</button>
+                    <button class="productivity-action productivity-action--danger" type="button" data-action="delete">Delete</button>
+                </div>
+            </li>
+        `;
+    }
+
+    function renderNoteItem(item) {
+        const isEditing = state.editingByType.notes === item.id;
+
+        if (isEditing) {
+            return `
+                <li class="productivity-item productivity-item--note productivity-item--editing" data-item-id="${item.id}" data-item-type="notes">
+                    <div class="productivity-item__editor productivity-item__editor--note">
+                        <textarea
+                            class="settings-input productivity-input productivity-textarea productivity-item__editor-textarea"
+                            data-edit-field="notes"
+                            name="content"
+                            rows="5"
+                            maxlength="1200"
+                        >${escapeHtml(item.content)}</textarea>
+                    </div>
+                    <div class="productivity-item__actions">
+                        <button class="productivity-action productivity-action--primary" type="button" data-action="save-edit">Save</button>
+                        <button class="productivity-action" type="button" data-action="cancel-edit">Cancel</button>
+                    </div>
+                </li>
+            `;
+        }
+
+        return `
+            <li class="productivity-item productivity-item--note" data-item-id="${item.id}" data-item-type="notes">
+                <article class="productivity-note">
+                    <p class="productivity-note__content">${escapeHtml(item.content).replaceAll("\n", "<br>")}</p>
+                    <p class="productivity-note__meta">Updated ${formatTimestamp(item.updatedAt)}</p>
+                </article>
+                <div class="productivity-item__actions">
+                    <button class="productivity-action" type="button" data-action="edit">Edit</button>
+                    <button class="productivity-action productivity-action--danger" type="button" data-action="delete">Delete</button>
+                </div>
+            </li>
+        `;
+    }
+
+    function renderType(type) {
+        const list = lists[type];
+        const items = state.items[type];
+        if (!list) return;
+
+        list.innerHTML = items.map(item => type === "todo" ? renderTodoItem(item) : renderNoteItem(item)).join("");
+
+        const emptyState = emptyStates[type];
+        if (emptyState) {
+            emptyState.classList.toggle("hidden", items.length > 0);
+        }
+    }
+
+    function render() {
+        ITEM_TYPES.forEach(type => {
+            clearFormMessage(type);
+            renderType(type);
+        });
+
+        setActiveTab(state.activeTab);
+    }
+
+    function handleAdd(type, form) {
+        const input = form.querySelector(`[name="${inputNames[type]}"]`);
+        const value = getTrimmedValue(type, form);
+
+        markInvalid(input, false);
+        clearFormMessage(type);
+
+        if (!value) {
+            markInvalid(input, true);
+            showFormMessage(type, `Please enter a ${itemLabels[type]} before adding it.`);
+            input?.focus();
+            return;
+        }
+
+        if (type === "todo") {
+            storageAdapter.create("todo", {
+                text: value,
+                completed: false
+            });
+        } else {
+            storageAdapter.create("notes", {
+                content: value
+            });
+        }
+
+        syncStateFromStorage();
+        form.reset();
+        renderType(type);
+        focusPrimaryInput(type);
+    }
+
+    function beginEditing(type, itemId) {
+        state.editingByType[type] = itemId;
+        renderType(type);
+        const editor = lists[type]?.querySelector(`[data-item-id="${itemId}"] [data-edit-field="${type}"]`);
+        editor?.focus();
+        if (editor && "selectionStart" in editor) {
+            editor.selectionStart = editor.value.length;
+            editor.selectionEnd = editor.value.length;
+        }
+    }
+
+    function stopEditing(type) {
+        state.editingByType[type] = null;
+        renderType(type);
+    }
+
+    function saveEdit(itemElement) {
+        const type = itemElement.dataset.itemType;
+        const itemId = itemElement.dataset.itemId;
+        const editor = itemElement.querySelector(`[data-edit-field="${type}"]`);
+        const nextValue = editor?.value.trim() || "";
+
+        markInvalid(editor, false);
+
+        if (!type || !itemId || !editor) return;
+
+        if (!nextValue) {
+            markInvalid(editor, true);
+            editor.focus();
+            return;
+        }
+
+        if (type === "todo") {
+            storageAdapter.update("todo", itemId, { text: nextValue });
+        } else {
+            storageAdapter.update("notes", itemId, { content: nextValue });
+        }
+
+        syncStateFromStorage();
+        state.editingByType[type] = null;
+        renderType(type);
+    }
+
+    tabButtons.forEach(button => {
+        button.addEventListener("click", () => {
+            setActiveTab(button.dataset.tabTrigger || DEFAULT_TAB);
+        });
+    });
+
+    ITEM_TYPES.forEach(type => {
+        forms[type]?.addEventListener("submit", event => {
+            event.preventDefault();
+            handleAdd(type, event.currentTarget);
+        });
+
+        forms[type]?.addEventListener("input", event => {
+            const input = event.target.closest(`[name="${inputNames[type]}"]`);
+            if (!input) return;
+
+            markInvalid(input, false);
+            clearFormMessage(type);
+        });
+
+        lists[type]?.addEventListener("click", event => {
+            const actionButton = event.target.closest("[data-action]");
+            if (!actionButton) return;
+
+            const itemElement = actionButton.closest("[data-item-id]");
+            const itemId = itemElement?.dataset.itemId;
+
+            if (!itemElement || !itemId) return;
+
+            switch (actionButton.dataset.action) {
+                case "edit":
+                    beginEditing(type, itemId);
+                    break;
+                case "delete":
+                    storageAdapter.delete(type, itemId);
+                    syncStateFromStorage();
+                    if (state.editingByType[type] === itemId) {
+                        state.editingByType[type] = null;
+                    }
+                    renderType(type);
+                    break;
+                case "cancel-edit":
+                    stopEditing(type);
+                    break;
+                case "save-edit":
+                    saveEdit(itemElement);
+                    break;
+                default:
+                    break;
+            }
+        });
+
+        lists[type]?.addEventListener("change", event => {
+            const checkbox = event.target.closest('[data-action="toggle-complete"]');
+            const itemElement = checkbox?.closest("[data-item-id]");
+            const itemId = itemElement?.dataset.itemId;
+
+            if (!checkbox || !itemId || type !== "todo") return;
+
+            storageAdapter.update("todo", itemId, {
+                completed: checkbox.checked
+            });
+            syncStateFromStorage();
+            renderType("todo");
+        });
+
+        lists[type]?.addEventListener("keydown", event => {
+            const itemElement = event.target.closest("[data-item-id]");
+            if (!itemElement) return;
+
+            const isTodoEditor = type === "todo" && event.key === "Enter";
+            const isNoteEditor = type === "notes" && event.key === "Enter" && (event.metaKey || event.ctrlKey);
+
+            if (!isTodoEditor && !isNoteEditor) return;
+
+            event.preventDefault();
+            saveEdit(itemElement);
+        });
+    });
+
+    window.addEventListener("storage", event => {
+        if (event.key !== STORAGE_KEY) return;
+        syncStateFromStorage();
+        renderType("todo");
+        renderType("notes");
+    });
+
+    render();
+});

--- a/src/main/resources/static/js/productivity.js
+++ b/src/main/resources/static/js/productivity.js
@@ -155,7 +155,12 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function formatTimestamp(value) {
-        return dateFormatter.format(new Date(value));
+        const date = value instanceof Date ? value : new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            // Fallback for corrupted or unparsable timestamps
+            return "";
+        }
+        return dateFormatter.format(date);
     }
 
     function syncStateFromStorage() {

--- a/src/main/resources/static/js/productivity.js
+++ b/src/main/resources/static/js/productivity.js
@@ -472,11 +472,20 @@ document.addEventListener("DOMContentLoaded", () => {
             const itemElement = event.target.closest("[data-item-id]");
             if (!itemElement) return;
 
-            const isTodoEditor = type === "todo" && event.key === "Enter";
-            const isNoteEditor = type === "notes" && event.key === "Enter" && (event.metaKey || event.ctrlKey);
+            const itemId = itemElement.dataset.itemId;
+            const isEditing = itemId && state.editingByType?.[type] === itemId;
 
-            if (!isTodoEditor && !isNoteEditor) return;
+            const keyIsTodoSave = type === "todo" && event.key === "Enter";
+            const keyIsNoteSave = type === "notes" && event.key === "Enter" && (event.metaKey || event.ctrlKey);
 
+            if (!keyIsTodoSave && !keyIsNoteSave) return;
+
+            // Only treat Enter as a save action when the focused element is an editor field
+            // within the item that is currently being edited.
+            const editorField = event.target.closest("input, textarea");
+            const editorBelongsToItem = editorField && itemElement.contains(editorField);
+
+            if (!isEditing || !editorBelongsToItem) return;
             event.preventDefault();
             saveEdit(itemElement);
         });

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -14,6 +14,7 @@
         </div>
         <nav class="nav">
             <a class="nav-btn" th:classappend="${activePage == 'home'} ? ' nav-btn--active' : ''" th:href="@{/}">Timer</a>
+            <a class="nav-btn" th:classappend="${activePage == 'productivity'} ? ' nav-btn--active' : ''" th:href="@{/productivity}">Productivity</a>
             <a class="nav-btn" th:classappend="${activePage == 'about'} ? ' nav-btn--active' : ''" th:href="@{/about}">About</a>
             <a class="nav-btn nav-btn--accent" th:classappend="${activePage == 'helpus'} ? ' nav-btn--active' : ''" th:href="@{/helpus}">Help Us</a>
         </nav>

--- a/src/main/resources/templates/productivity.html
+++ b/src/main/resources/templates/productivity.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Productivity - Telos</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+    <link rel="icon" th:href="@{/assets/icon/icon.ico}" type="image/x-icon">
+</head>
+<body>
+    <th:block th:replace="~{fragments/header :: header('productivity')}"></th:block>
+
+    <main class="main-content">
+        <div class="container productivity-shell">
+            <div class="page-intro">
+                <p class="eyebrow">Focus Support</p>
+                <h2 class="page-title productivity-title">Productivity</h2>
+                <p class="page-lead productivity-lead">
+                    Capture short tasks and working notes without leaving the timer workflow.
+                </p>
+            </div>
+
+            <section class="productivity-surface" aria-label="Productivity tools">
+                <div class="productivity-tabs" role="tablist" aria-label="Productivity tabs">
+                    <button
+                        id="productivity-tab-todo"
+                        class="productivity-tab productivity-tab--active"
+                        type="button"
+                        role="tab"
+                        aria-selected="true"
+                        tabindex="0"
+                        aria-controls="productivity-panel-todo"
+                        data-tab-trigger="todo"
+                    >
+                        To-do
+                    </button>
+                    <button
+                        id="productivity-tab-notes"
+                        class="productivity-tab"
+                        type="button"
+                        role="tab"
+                        aria-selected="false"
+                        tabindex="-1"
+                        aria-controls="productivity-panel-notes"
+                        data-tab-trigger="notes"
+                    >
+                        Notes
+                    </button>
+                </div>
+
+                <div class="productivity-panels">
+                    <section
+                        id="productivity-panel-todo"
+                        class="productivity-panel"
+                        role="tabpanel"
+                        aria-labelledby="productivity-tab-todo"
+                        aria-hidden="false"
+                        data-tab-panel="todo"
+                    >
+                        <form class="productivity-entry-form" data-entry-form="todo" novalidate>
+                            <div class="productivity-field">
+                                <label class="settings-label" for="todoInput">Task</label>
+                                <input
+                                    id="todoInput"
+                                    class="settings-input productivity-input"
+                                    name="text"
+                                    type="text"
+                                    maxlength="160"
+                                    placeholder="Add a task you want to track"
+                                    autocomplete="off"
+                                >
+                            </div>
+                            <div class="productivity-form-actions">
+                                <button class="btn btn--primary productivity-submit" type="submit">Add task</button>
+                            </div>
+                            <p class="form-message hidden" data-form-message="todo" aria-live="polite"></p>
+                        </form>
+
+                        <ul class="productivity-list" data-item-list="todo" aria-live="polite"></ul>
+                        <p class="productivity-empty-state" data-empty-state="todo">
+                            No tasks yet. Add the first one to build your list.
+                        </p>
+                    </section>
+
+                    <section
+                        id="productivity-panel-notes"
+                        class="productivity-panel hidden"
+                        role="tabpanel"
+                        aria-labelledby="productivity-tab-notes"
+                        aria-hidden="true"
+                        data-tab-panel="notes"
+                    >
+                        <form class="productivity-entry-form" data-entry-form="notes" novalidate>
+                            <div class="productivity-field">
+                                <label class="settings-label" for="noteInput">Note</label>
+                                <textarea
+                                    id="noteInput"
+                                    class="settings-input productivity-input productivity-textarea"
+                                    name="content"
+                                    rows="5"
+                                    maxlength="1200"
+                                    placeholder="Write a note, idea, or follow-up for later"
+                                ></textarea>
+                            </div>
+                            <div class="productivity-form-actions">
+                                <button class="btn btn--primary productivity-submit" type="submit">Add note</button>
+                            </div>
+                            <p class="form-message hidden" data-form-message="notes" aria-live="polite"></p>
+                        </form>
+
+                        <ul class="productivity-list productivity-list--notes" data-item-list="notes" aria-live="polite"></ul>
+                        <p class="productivity-empty-state" data-empty-state="notes">
+                            No notes yet. Add one to keep context close to your work.
+                        </p>
+                    </section>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <th:block th:replace="~{fragments/footer :: footer}"></th:block>
+
+    <th:block th:replace="~{fragments/mini-timer-scripts :: scripts}"></th:block>
+    <script th:src="@{/js/productivity.js}"></script>
+</body>
+</html>

--- a/src/test/java/com/example/telos/controllerTests/ProductivityControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/ProductivityControllerTest.java
@@ -1,0 +1,25 @@
+package com.example.telos.controllerTests;
+
+import com.example.telos.controller.ProductivityController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@WebMvcTest(ProductivityController.class)
+public class ProductivityControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnProductivityPage() throws Exception {
+        mockMvc.perform(get("/productivity"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("productivity"));
+    }
+}


### PR DESCRIPTION
Introduce a new Productivity feature: adds a /productivity route and controller, Thymeleaf template (productivity.html), client JS (productivity.js) for localStorage-backed todo/notes interactions, and extensive CSS styles. Updates header navigation to include the new page and updates SecurityConfig to allow access to /productivity. Includes a simple WebMvcTest (ProductivityControllerTest) to verify the controller returns the productivity view.