### PR TITLE
Add automation roadmap and update test READMEs

### DIFF
--- a/tests/AutomationRoadmap.md
+++ b/tests/AutomationRoadmap.md
@@ -1,0 +1,228 @@
+# Test Automation Roadmap
+
+This document translates the written scenario coverage under `tests/` into an implementation order for future automation.
+
+## Goals
+
+- convert the most critical documented scenarios into stable automated checks
+- separate backend contract coverage from browser behavior coverage
+- avoid writing brittle UI tests where lower-level tests can cover the same rule cheaper
+- keep the current split page docs usable as direct input for automation backlog items
+
+## Recommended Automation Stack
+
+### 1. WebMvc / Spring Security / API Contract Layer
+
+Use for:
+
+- page controller smoke and auth guards
+- session API contracts under `/api/user/**`
+- JWT API contracts under `/api/jwt/**`
+- CSRF behavior
+- redirect behavior
+- error response shape
+
+Best fit for:
+
+- `login`
+- `user`
+- `error-*`
+- auth and transport-focused parts of `index`
+
+### 2. Spring Boot Integration Layer
+
+Use for:
+
+- context startup
+- authentication manager wiring
+- persistence behavior around user and time settings
+- exception handler and security filter integration
+- DB-backed flows that are too coupled for pure `@WebMvcTest`
+
+Recommended future upgrade:
+
+- introduce Testcontainers for PostgreSQL when DB-backed automation becomes a priority
+
+### 3. Playwright Browser Layer
+
+Use for:
+
+- timer UI
+- settings panel interaction
+- login browser flow
+- user profile form behavior
+- productivity page behavior
+- cross-tab storage sync
+- shared UI rendering across pages
+
+Best fit for:
+
+- `index`
+- `productivity`
+- `user`
+- `header`
+- `mini-timer-scripts`
+
+### 4. Optional JS Unit Layer
+
+Use only if the team wants faster and narrower feedback on pure frontend logic.
+
+Best fit for:
+
+- `timer-state.js`
+- future extracted storage helpers from `productivity.js`
+
+Recommendation:
+
+- do not start here first
+- add this layer only after WebMvc and Playwright coverage exist for the critical paths
+
+## Phase Plan
+
+### Phase 0: Automation Readiness
+
+- add JaCoCo to Maven so backend coverage can be measured
+- define naming/tagging convention for automated tests:
+  - smoke
+  - regression
+  - auth
+  - api
+  - ui
+- decide whether browser automation will live in Playwright or another runner and commit the config to the repo
+- document DB reset strategy for mutable tests
+- keep using the split docs as the source of truth for test cases
+
+### Phase 1: P0 Backend Safety Net
+
+Automate first:
+
+- login success and invalid credentials
+- protected `/user` route behavior
+- session time-settings GET/PATCH contract
+- session username/password PATCH contract
+- JWT login contract
+- JWT username/password/time-settings contract
+
+Source docs to start from:
+
+- `tests/login`
+- `tests/user`
+- `tests/index/08-authenticated-settings-sync.md`
+
+### Phase 2: P0 Browser Journeys
+
+Automate first:
+
+- home page timer shell renders correctly
+- start / pause / reset timer controls
+- settings validation and save/cancel behavior
+- authenticated settings sync visible in UI
+- productivity todo and notes happy paths
+- user page profile happy paths
+
+Source docs to start from:
+
+- `tests/index`
+- `tests/productivity`
+- `tests/user`
+
+### Phase 3: Shared UI And Error Surfaces
+
+Automate next:
+
+- header anonymous/authenticated states
+- footer presence across page types
+- mini-timer runtime behavior on non-home pages
+- 403 and 404 page recovery flows
+
+Source docs to start from:
+
+- `tests/header`
+- `tests/footer`
+- `tests/mini-timer-scripts`
+- `tests/error-403`
+- `tests/error-404`
+
+### Phase 4: Secondary Static Coverage
+
+Automate last:
+
+- about page smoke
+- helpus page smoke
+- outbound link assertions
+- generic error template rendering
+
+Source docs to start from:
+
+- `tests/about`
+- `tests/helpus`
+- `tests/error-generic`
+
+## Selector And Hook Strategy
+
+Prefer existing stable hooks before adding new ones.
+
+Already stable enough for browser automation:
+
+- `#startBtn`
+- `#resetBtn`
+- `#settingsToggle`
+- `#pomodoroTime`
+- `#shortBreakTime`
+- `#longBreakTime`
+- `#focusCycles`
+- `#soundEnabled`
+- `#timeDisplay`
+- `#sessionProjectionText`
+- `#todoInput`
+- `#noteInput`
+- `#username`
+- `#oldPassword`
+- `#newPassword`
+- `#confirmNewPassword`
+- `#miniTimer`
+
+Use existing data attributes where present:
+
+- `data-tab-trigger`
+- `data-tab-panel`
+- `data-entry-form`
+- `data-item-list`
+- `data-empty-state`
+- `data-form-message`
+- `data-action`
+
+Only add `data-testid` later if:
+
+- a selector is currently style-driven and brittle
+- a block has no stable id/data hook
+- shared UI is too expensive to target semantically
+
+## Test Data And Reset Strategy
+
+- use seeded users for read-only auth coverage
+- create one dedicated mutable test user for username/password update flows
+- clear `localStorage` before browser specs that hit timer/productivity pages
+- treat `pomodoroSettings`, `pomodoroTimerState`, and `telos.productivity.v1` as part of test setup and teardown
+- keep browser tests isolated from each other so cross-tab tests are explicit, not accidental
+
+## CI Recommendation
+
+- PR lane:
+  - backend smoke
+  - critical WebMvc/API contracts
+  - a tiny browser smoke set
+- nightly or pre-release lane:
+  - full browser regression
+  - cross-tab and storage sync flows
+  - extended auth and error-page coverage
+
+## Definition Of “Automation-Ready”
+
+A page or fragment folder is automation-ready when:
+
+- the README specifies the primary automation layer
+- scenario files are granular enough to map to one future suite or spec file
+- selectors/hooks are known
+- auth/storage/API prerequisites are explicitly written
+- no hidden product decisions are left inside the scenario text

--- a/tests/TestPlan01.md
+++ b/tests/TestPlan01.md
@@ -4,6 +4,8 @@ This file is the entrypoint for the split test-plan structure under `tests/`.
 
 The original monolithic page plan has been decomposed into page-level and shared-UI folders so each functional slice can later map cleanly to manual checks, automated specs, or implementation tasks.
 
+For the implementation order and automation strategy, see [AutomationRoadmap.md](AutomationRoadmap.md).
+
 ## How To Use This Structure
 
 - Start with the page or fragment you want to test.
@@ -102,6 +104,13 @@ The original monolithic page plan has been decomposed into page-level and shared
 - Numbered files like `01-...md`, `02-...md` define smaller scenarios by block, user story, or functionality.
 - Dynamic pages separate rendering from stateful behavior so future automation can map one file to one test suite concern.
 - Page folders may reference shared behavior, but shared docs remain the canonical source for repeated UI rules.
+
+## Automation Conventions
+
+- Prefer `WebMvc` for route/auth/contract checks.
+- Prefer browser automation for JS-driven UI behavior and cross-tab state.
+- Use the folder README as the place to declare automation priority, stable selectors, and first implementation slices.
+- Treat the split docs as backlog-ready inputs, not just narrative notes.
 
 ## Implementation Notes
 

--- a/tests/about/README.md
+++ b/tests/about/README.md
@@ -19,7 +19,14 @@
 - page shell and static copy
 - shared UI presence on a simple public page
 
+## Automation Notes
+
+- Primary automation layer: `WebMvc smoke`
+- Secondary layer: `Playwright smoke` if this page is used in a full public-pages suite
+- Priority: `P2`
+- Selectors can stay semantic unless the page gains interactive UI later
+
 ## Plans
 
-- [01-page-shell-and-static-copy.md](01-page-shell-and-static-copy.md)
-- [02-shared-ui-presence.md](02-shared-ui-presence.md)
+- [01-page-shell-and-static-copy.md](01-page-shell-and-static-copy.md) — `WebMvc smoke`
+- [02-shared-ui-presence.md](02-shared-ui-presence.md) — `Playwright smoke`

--- a/tests/error-403/README.md
+++ b/tests/error-403/README.md
@@ -19,8 +19,18 @@
 - recovery navigation
 - shared header/footer behavior on a custom error page
 
+## Automation Notes
+
+- Primary automation layer: `WebMvc` / integration
+- Secondary layer: `Playwright smoke`
+- Priority: `P1`
+- Good first checks:
+  - forbidden route renders custom 403 page
+  - recovery link points home
+  - no full mini-timer runtime is assumed
+
 ## Plans
 
-- [01-access-denied-content.md](01-access-denied-content.md)
-- [02-recovery-navigation.md](02-recovery-navigation.md)
-- [03-shared-header-footer-behavior.md](03-shared-header-footer-behavior.md)
+- [01-access-denied-content.md](01-access-denied-content.md) — `WebMvc / integration`
+- [02-recovery-navigation.md](02-recovery-navigation.md) — `Playwright smoke`
+- [03-shared-header-footer-behavior.md](03-shared-header-footer-behavior.md) — `Playwright`

--- a/tests/error-404/README.md
+++ b/tests/error-404/README.md
@@ -21,8 +21,18 @@
 - recovery navigation
 - partial mini-timer script inclusion
 
+## Automation Notes
+
+- Primary automation layer: `WebMvc` / integration
+- Secondary layer: `Playwright`
+- Priority: `P1`
+- Good first checks:
+  - missing route renders custom 404 page
+  - recovery link works
+  - page-specific mini-timer script behavior stays distinct from other pages
+
 ## Plans
 
-- [01-not-found-content.md](01-not-found-content.md)
-- [02-recovery-navigation.md](02-recovery-navigation.md)
-- [03-mini-timer-script-inclusion.md](03-mini-timer-script-inclusion.md)
+- [01-not-found-content.md](01-not-found-content.md) — `WebMvc / integration`
+- [02-recovery-navigation.md](02-recovery-navigation.md) — `Playwright smoke`
+- [03-mini-timer-script-inclusion.md](03-mini-timer-script-inclusion.md) — `Playwright`

--- a/tests/error-generic/README.md
+++ b/tests/error-generic/README.md
@@ -16,7 +16,13 @@
 - model rendering for code and message
 - intentionally minimal template behavior
 
+## Automation Notes
+
+- Primary automation layer: `integration`
+- Priority: `P2`
+- This page is better covered through server-side rendering assertions than browser-heavy tests because it is intentionally minimal
+
 ## Plans
 
-- [01-model-rendering-code-and-message.md](01-model-rendering-code-and-message.md)
-- [02-minimal-template-behavior.md](02-minimal-template-behavior.md)
+- [01-model-rendering-code-and-message.md](01-model-rendering-code-and-message.md) — `integration`
+- [02-minimal-template-behavior.md](02-minimal-template-behavior.md) — `integration`

--- a/tests/footer/README.md
+++ b/tests/footer/README.md
@@ -14,7 +14,16 @@
 - footer copy and link
 - footer visibility across page types
 
+## Automation Notes
+
+- Primary automation layer: `Playwright smoke`
+- Priority: `P2`
+- Stable hooks currently rely on semantic/footer selectors; add `data-testid` only if selectors become brittle
+- First automation slices to implement:
+  - footer presence on standard pages
+  - footer absence on generic error page
+
 ## Plans
 
-- [01-footer-copy-and-link.md](01-footer-copy-and-link.md)
-- [02-global-visibility-across-pages.md](02-global-visibility-across-pages.md)
+- [01-footer-copy-and-link.md](01-footer-copy-and-link.md) — `Playwright smoke`
+- [02-global-visibility-across-pages.md](02-global-visibility-across-pages.md) — `Playwright`

--- a/tests/header/README.md
+++ b/tests/header/README.md
@@ -24,10 +24,26 @@
 - authenticated account menu
 - mini-timer slot rules
 
+## Automation Notes
+
+- Primary automation layer: `Playwright smoke`
+- Secondary layer: `WebMvc` only for page-level active-state assertions where cheaper
+- Priority: `P1`
+- Stable hooks already available:
+  - `#miniTimer`
+  - `#miniTimerMode`
+  - `#miniTimerTime`
+  - `#miniTimerStatus`
+  - `#profileEntry`
+- First automation slices to implement:
+  - active nav state on key pages
+  - anonymous vs authenticated header mode
+  - mini-timer slot presence on non-home pages
+
 ## Plans
 
-- [01-branding-and-home-link.md](01-branding-and-home-link.md)
-- [02-primary-navigation.md](02-primary-navigation.md)
-- [03-anonymous-auth-controls.md](03-anonymous-auth-controls.md)
-- [04-authenticated-account-menu.md](04-authenticated-account-menu.md)
-- [05-mini-timer-slot-rules.md](05-mini-timer-slot-rules.md)
+- [01-branding-and-home-link.md](01-branding-and-home-link.md) — `Playwright smoke`
+- [02-primary-navigation.md](02-primary-navigation.md) — `Playwright` + targeted `WebMvc`
+- [03-anonymous-auth-controls.md](03-anonymous-auth-controls.md) — `Playwright`
+- [04-authenticated-account-menu.md](04-authenticated-account-menu.md) — `Playwright` + `integration`
+- [05-mini-timer-slot-rules.md](05-mini-timer-slot-rules.md) — `Playwright`

--- a/tests/helpus/README.md
+++ b/tests/helpus/README.md
@@ -21,9 +21,19 @@
 - donation block and QR image
 - external link behavior
 
+## Automation Notes
+
+- Primary automation layer: `Playwright`
+- Secondary layer: `WebMvc smoke` for page render only
+- Priority: `P2`
+- Good candidates for browser assertions:
+  - external links
+  - QR image presence
+  - support copy visibility
+
 ## Plans
 
-- [01-page-shell-and-static-copy.md](01-page-shell-and-static-copy.md)
-- [02-support-options-links.md](02-support-options-links.md)
-- [03-donation-block-and-image.md](03-donation-block-and-image.md)
-- [04-external-link-behavior.md](04-external-link-behavior.md)
+- [01-page-shell-and-static-copy.md](01-page-shell-and-static-copy.md) — `WebMvc smoke`
+- [02-support-options-links.md](02-support-options-links.md) — `Playwright`
+- [03-donation-block-and-image.md](03-donation-block-and-image.md) — `Playwright`
+- [04-external-link-behavior.md](04-external-link-behavior.md) — `Playwright`

--- a/tests/index/README.md
+++ b/tests/index/README.md
@@ -41,13 +41,37 @@
 - [Footer](../footer/README.md)
 - [Mini timer scripts](../mini-timer-scripts/README.md)
 
+## Automation Notes
+
+- Primary automation layer: `Playwright`
+- Secondary layers:
+  - `WebMvc` for transport/auth edges around settings APIs
+  - future JS-unit layer for `timer-state.js` if introduced
+- Priority: `P0`
+- Stable hooks already available:
+  - `#startBtn`
+  - `#resetBtn`
+  - `#settingsToggle`
+  - `#timeDisplay`
+  - `#sessionProjectionText`
+  - `#pomodoroTime`
+  - `#shortBreakTime`
+  - `#longBreakTime`
+  - `#focusCycles`
+  - `#soundEnabled`
+- First automation slices to implement:
+  - shell/meta smoke
+  - timer controls
+  - settings validation
+  - authenticated settings sync
+
 ## Plans
 
-- [01-page-shell-and-meta.md](01-page-shell-and-meta.md)
-- [02-timer-modes.md](02-timer-modes.md)
-- [03-timer-display-and-progress.md](03-timer-display-and-progress.md)
-- [04-timer-controls-start-pause-reset.md](04-timer-controls-start-pause-reset.md)
-- [05-session-counters-and-projection.md](05-session-counters-and-projection.md)
-- [06-settings-panel-fields.md](06-settings-panel-fields.md)
-- [07-settings-save-cancel-validation.md](07-settings-save-cancel-validation.md)
-- [08-authenticated-settings-sync.md](08-authenticated-settings-sync.md)
+- [01-page-shell-and-meta.md](01-page-shell-and-meta.md) — `WebMvc smoke` + `Playwright smoke`
+- [02-timer-modes.md](02-timer-modes.md) — `Playwright` + future `timer-state` unit coverage
+- [03-timer-display-and-progress.md](03-timer-display-and-progress.md) — `Playwright`
+- [04-timer-controls-start-pause-reset.md](04-timer-controls-start-pause-reset.md) — `Playwright P0`
+- [05-session-counters-and-projection.md](05-session-counters-and-projection.md) — `Playwright` + future `timer-state` unit coverage
+- [06-settings-panel-fields.md](06-settings-panel-fields.md) — `Playwright`
+- [07-settings-save-cancel-validation.md](07-settings-save-cancel-validation.md) — `Playwright P0`
+- [08-authenticated-settings-sync.md](08-authenticated-settings-sync.md) — `WebMvc API` + `Playwright P0`

--- a/tests/login/README.md
+++ b/tests/login/README.md
@@ -22,9 +22,24 @@
 - successful login and redirect
 - error states for invalid credentials
 
+## Automation Notes
+
+- Primary automation layers:
+  - `WebMvc` / Spring Security integration
+  - `Playwright` for end-to-end browser login flow
+- Priority: `P0`
+- Stable hooks already available:
+  - `#loginForm`
+  - `#loginIdentifier`
+  - `#loginPassword`
+- First automation slices to implement:
+  - GET `/login` smoke
+  - valid login redirect to `/user`
+  - invalid credentials stay in login flow with error message
+
 ## Plans
 
-- [01-page-shell-and-layout.md](01-page-shell-and-layout.md)
-- [02-login-form-fields-and-csrf.md](02-login-form-fields-and-csrf.md)
-- [03-login-success-and-redirect.md](03-login-success-and-redirect.md)
-- [04-login-error-and-invalid-credentials.md](04-login-error-and-invalid-credentials.md)
+- [01-page-shell-and-layout.md](01-page-shell-and-layout.md) — `WebMvc smoke`
+- [02-login-form-fields-and-csrf.md](02-login-form-fields-and-csrf.md) — `WebMvc`
+- [03-login-success-and-redirect.md](03-login-success-and-redirect.md) — `integration` + `Playwright P0`
+- [04-login-error-and-invalid-credentials.md](04-login-error-and-invalid-credentials.md) — `integration` + `Playwright P0`

--- a/tests/mini-timer-scripts/README.md
+++ b/tests/mini-timer-scripts/README.md
@@ -25,8 +25,23 @@
 - runtime contract with header mini-timer markup
 - settings sync side effects
 
+## Automation Notes
+
+- Primary automation layer: `Playwright`
+- Secondary layer: future JS-unit coverage only if the timer runtime gets isolated further
+- Priority: `P1`
+- Stable hooks already available:
+  - `#miniTimer`
+  - `#miniTimerMode`
+  - `#miniTimerTime`
+  - `#miniTimerStatus`
+- First automation slices to implement:
+  - mini-timer hydration on non-home pages
+  - storage-driven updates
+  - authenticated sync side effects
+
 ## Plans
 
-- [01-script-injection-order.md](01-script-injection-order.md)
-- [02-mini-timer-runtime-contract.md](02-mini-timer-runtime-contract.md)
-- [03-settings-sync-side-effects.md](03-settings-sync-side-effects.md)
+- [01-script-injection-order.md](01-script-injection-order.md) — `Playwright smoke`
+- [02-mini-timer-runtime-contract.md](02-mini-timer-runtime-contract.md) — `Playwright P1`
+- [03-settings-sync-side-effects.md](03-settings-sync-side-effects.md) — `Playwright P1`

--- a/tests/productivity/README.md
+++ b/tests/productivity/README.md
@@ -33,12 +33,34 @@
 - [Footer](../footer/README.md)
 - [Mini timer scripts](../mini-timer-scripts/README.md)
 
+## Automation Notes
+
+- Primary automation layer: `Playwright`
+- Secondary layer: future lightweight JS-unit coverage only if storage logic gets extracted
+- Priority: `P0`
+- Stable hooks already available:
+  - `#todoInput`
+  - `#noteInput`
+  - `data-tab-trigger`
+  - `data-tab-panel`
+  - `data-entry-form`
+  - `data-item-list`
+  - `data-empty-state`
+  - `data-form-message`
+  - `data-action`
+- First automation slices to implement:
+  - tab switching
+  - todo happy path
+  - notes happy path
+  - localStorage persistence
+  - cross-tab sync
+
 ## Plans
 
-- [01-page-shell-and-tabs.md](01-page-shell-and-tabs.md)
-- [02-todo-form-and-empty-state.md](02-todo-form-and-empty-state.md)
-- [03-todo-item-lifecycle.md](03-todo-item-lifecycle.md)
-- [04-notes-form-and-empty-state.md](04-notes-form-and-empty-state.md)
-- [05-note-item-lifecycle.md](05-note-item-lifecycle.md)
-- [06-local-storage-and-cross-tab-sync.md](06-local-storage-and-cross-tab-sync.md)
-- [07-keyboard-and-a11y-states.md](07-keyboard-and-a11y-states.md)
+- [01-page-shell-and-tabs.md](01-page-shell-and-tabs.md) — `Playwright smoke`
+- [02-todo-form-and-empty-state.md](02-todo-form-and-empty-state.md) — `Playwright P0`
+- [03-todo-item-lifecycle.md](03-todo-item-lifecycle.md) — `Playwright P0`
+- [04-notes-form-and-empty-state.md](04-notes-form-and-empty-state.md) — `Playwright P0`
+- [05-note-item-lifecycle.md](05-note-item-lifecycle.md) — `Playwright P0`
+- [06-local-storage-and-cross-tab-sync.md](06-local-storage-and-cross-tab-sync.md) — `Playwright P1`
+- [07-keyboard-and-a11y-states.md](07-keyboard-and-a11y-states.md) — `Playwright P1`

--- a/tests/user/README.md
+++ b/tests/user/README.md
@@ -35,10 +35,31 @@
 - [Footer](../footer/README.md)
 - [Mini timer scripts](../mini-timer-scripts/README.md)
 
+## Automation Notes
+
+- Primary automation layers:
+  - `WebMvc` / integration for auth guards and API contracts
+  - `Playwright` for browser form behavior
+- Priority: `P0`
+- Stable hooks already available:
+  - `#username-form`
+  - `#password-form`
+  - `#username`
+  - `#oldPassword`
+  - `#newPassword`
+  - `#confirmNewPassword`
+  - `#username-message`
+  - `#password-message`
+- First automation slices to implement:
+  - auth guard on `/user`
+  - username happy path and conflict path
+  - password happy path and invalid current password path
+  - CSRF/session contract checks
+
 ## Plans
 
-- [01-page-shell-and-auth-guard.md](01-page-shell-and-auth-guard.md)
-- [02-username-form.md](02-username-form.md)
-- [03-password-form.md](03-password-form.md)
-- [04-session-api-feedback-and-csrf.md](04-session-api-feedback-and-csrf.md)
-- [05-jwt-api-parity-notes.md](05-jwt-api-parity-notes.md)
+- [01-page-shell-and-auth-guard.md](01-page-shell-and-auth-guard.md) — `WebMvc P0`
+- [02-username-form.md](02-username-form.md) — `Playwright` + `WebMvc API`
+- [03-password-form.md](03-password-form.md) — `Playwright` + `WebMvc API`
+- [04-session-api-feedback-and-csrf.md](04-session-api-feedback-and-csrf.md) — `WebMvc / integration P0`
+- [05-jwt-api-parity-notes.md](05-jwt-api-parity-notes.md) — `WebMvc JWT API P1`


### PR DESCRIPTION
Add tests/AutomationRoadmap.md to define goals, recommended automation stack (WebMvc/Spring integration, Playwright, optional JS unit), phased implementation plan, selector/hook strategy, test data/reset guidance, and CI recommendations. Update tests/TestPlan01.md to reference the roadmap and add automation conventions. Inject automation notes (preferred layer, priority, stable selectors, and initial automation slices) into multiple page README files (about, error-403, error-404, error-generic, footer, header, helpus, index, login, mini-timer-scripts, productivity, user) so the split test docs are backlog-ready for implementation.