### PR TITLE
Add tests and fix minor issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
@@ -117,6 +123,19 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/com/example/telos/controller/api/jwt/AuthJwtController.java
+++ b/src/main/java/com/example/telos/controller/api/jwt/AuthJwtController.java
@@ -5,6 +5,7 @@ import com.example.telos.dto.AuthResponse;
 import com.example.telos.model.User;
 import com.example.telos.security.JwtService;
 import com.example.telos.service.UserService;
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -23,7 +24,7 @@ public class AuthJwtController {
     private final UserService userService;
 
     @PostMapping("/login")
-    public AuthResponse login(@RequestBody AuthRequest authRequest) {
+    public AuthResponse login(@Valid @RequestBody AuthRequest authRequest) {
         authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         authRequest.getLogin(),

--- a/src/main/java/com/example/telos/dto/AuthRequest.java
+++ b/src/main/java/com/example/telos/dto/AuthRequest.java
@@ -3,12 +3,15 @@ package com.example.telos.dto;
 import lombok.Getter;
 import lombok.Setter;
 import jakarta.validation.constraints.NotBlank;
+import com.example.telos.validation.NoForbidden67Token;
 
 @Getter
 @Setter
 public class AuthRequest {
-    @NotBlank
+    @NotBlank(message = "login cannot be empty")
+    @NoForbidden67Token
     private String login;
-    @NotBlank
+
+    @NotBlank(message = "password cannot be empty")
     private String password;
 }

--- a/src/main/java/com/example/telos/dto/UserPasswordDto.java
+++ b/src/main/java/com/example/telos/dto/UserPasswordDto.java
@@ -1,6 +1,7 @@
 package com.example.telos.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,6 +15,7 @@ public class UserPasswordDto {
     private String oldPassword;
 
     @NotBlank(message = "newPassword cannot be empty")
+    @Size(min = 8, message = "newPassword must be at least 8 characters")
     private String newPassword;
 
     @NotBlank(message = "confirmPassword cannot be empty")

--- a/src/main/java/com/example/telos/dto/UserUsernameDto.java
+++ b/src/main/java/com/example/telos/dto/UserUsernameDto.java
@@ -4,11 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import com.example.telos.validation.NoForbidden67Token;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class UserUsernameDto {
     @NotBlank(message = "username cannot be empty")
+    @NoForbidden67Token
     private String username;
 }

--- a/src/main/java/com/example/telos/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/telos/service/impl/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.telos.exception.UsernameAlreadyTakenException;
 import com.example.telos.model.User;
 import com.example.telos.repository.UserRepository;
 import com.example.telos.service.UserService;
+import com.example.telos.validation.Forbidden67Policy;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
@@ -79,6 +80,9 @@ public class UserServiceImpl implements UserService {
         if (username == null || username.isBlank())
             throw new NullEntityReferenceException("Username cannot be empty");
 
+        if (Forbidden67Policy.containsForbiddenToken(username))
+            throw new IllegalArgumentException(Forbidden67Policy.DEFAULT_MESSAGE);
+
         Optional<User> checkUser = userRepository.findByUsername(username.trim());
         User user = findByEmailOrUsername(login);
 
@@ -105,6 +109,9 @@ public class UserServiceImpl implements UserService {
 
         if (!userPasswordDto.getNewPassword().equals(userPasswordDto.getConfirmNewPassword()))
             throw new IllegalArgumentException("New password and confirm password don't match");
+
+        if (userPasswordDto.getNewPassword().length() < 8)
+            throw new IllegalArgumentException("New password must be at least 8 characters");
 
         User user = findByEmailOrUsername(login);
 

--- a/src/main/java/com/example/telos/validation/Forbidden67Policy.java
+++ b/src/main/java/com/example/telos/validation/Forbidden67Policy.java
@@ -1,0 +1,21 @@
+package com.example.telos.validation;
+
+public final class Forbidden67Policy {
+
+    public static final String DEFAULT_MESSAGE = "67 and six seven are not allowed here";
+
+    private Forbidden67Policy() {
+    }
+
+    public static boolean containsForbiddenToken(String value) {
+        if (value == null) {
+            return false;
+        }
+
+        String normalized = value.trim()
+                .replaceAll("\\s+", " ")
+                .toLowerCase();
+
+        return "67".equals(normalized) || "six seven".equals(normalized);
+    }
+}

--- a/src/main/java/com/example/telos/validation/NoForbidden67Token.java
+++ b/src/main/java/com/example/telos/validation/NoForbidden67Token.java
@@ -1,0 +1,22 @@
+package com.example.telos.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = NoForbidden67TokenValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoForbidden67Token {
+    String message() default Forbidden67Policy.DEFAULT_MESSAGE;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/telos/validation/NoForbidden67TokenValidator.java
+++ b/src/main/java/com/example/telos/validation/NoForbidden67TokenValidator.java
@@ -1,0 +1,11 @@
+package com.example.telos.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NoForbidden67TokenValidator implements ConstraintValidator<NoForbidden67Token, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return !Forbidden67Policy.containsForbiddenToken(value);
+    }
+}

--- a/src/main/resources/static/js/login-validation.js
+++ b/src/main/resources/static/js/login-validation.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+    const FORBIDDEN_VALUE_MESSAGE = "67 and six seven are not allowed here.";
     const form = document.querySelector("#loginForm");
     const identifierInput = document.querySelector("#loginIdentifier");
     const passwordInput = document.querySelector("#loginPassword");
@@ -35,6 +36,11 @@ document.addEventListener("DOMContentLoaded", () => {
         formMessage.classList.add("form-message--error");
     }
 
+    function hasForbiddenIdentifier(value) {
+        const normalized = value.trim().replace(/\s+/g, " ").toLowerCase();
+        return normalized === "67" || normalized === "six seven";
+    }
+
     function clearFormMessage() {
         if (!formMessage) return;
 
@@ -46,7 +52,8 @@ document.addEventListener("DOMContentLoaded", () => {
     function updateSubmitState() {
         const hasIdentifier = Boolean(identifierInput.value.trim());
         const hasPassword = Boolean(passwordInput.value.trim());
-        const isDisabled = !hasIdentifier || !hasPassword;
+        const hasForbiddenIdentifierValue = hasForbiddenIdentifier(identifierInput.value);
+        const isDisabled = !hasIdentifier || !hasPassword || hasForbiddenIdentifierValue;
 
         submitButton.disabled = isDisabled;
         submitButton.setAttribute("aria-disabled", isDisabled ? "true" : "false");
@@ -58,6 +65,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (!identifierInput.value.trim()) {
             showFieldError(identifierInput, identifierError, "Email or username is required");
+            isValid = false;
+        } else if (hasForbiddenIdentifier(identifierInput.value)) {
+            showFieldError(identifierInput, identifierError, FORBIDDEN_VALUE_MESSAGE);
             isValid = false;
         } else {
             clearFieldError(identifierInput, identifierError);
@@ -78,6 +88,9 @@ document.addEventListener("DOMContentLoaded", () => {
         input.addEventListener("input", () => {
             if (input === identifierInput) {
                 clearFieldError(identifierInput, identifierError);
+                if (hasForbiddenIdentifier(identifierInput.value)) {
+                    showFieldError(identifierInput, identifierError, FORBIDDEN_VALUE_MESSAGE);
+                }
             } else {
                 clearFieldError(passwordInput, passwordError);
             }
@@ -90,7 +103,11 @@ document.addEventListener("DOMContentLoaded", () => {
     form.addEventListener("submit", event => {
         if (!validateForm()) {
             event.preventDefault();
-            showFormMessage("Fill in both required fields before continuing.");
+            showFormMessage(
+                hasForbiddenIdentifier(identifierInput.value)
+                    ? FORBIDDEN_VALUE_MESSAGE
+                    : "Fill in both required fields before continuing."
+            );
         }
     });
 

--- a/src/main/resources/static/js/login-validation.js
+++ b/src/main/resources/static/js/login-validation.js
@@ -1,0 +1,98 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const form = document.querySelector("#loginForm");
+    const identifierInput = document.querySelector("#loginIdentifier");
+    const passwordInput = document.querySelector("#loginPassword");
+    const submitButton = form?.querySelector(".auth-submit");
+    const formMessage = document.querySelector("[data-form-message]");
+    const identifierError = document.querySelector('[data-error-for="loginIdentifier"]');
+    const passwordError = document.querySelector('[data-error-for="loginPassword"]');
+
+    if (!form || !identifierInput || !passwordInput || !submitButton) return;
+
+    function showFieldError(input, errorElement, message) {
+        if (!input || !errorElement) return;
+
+        input.setAttribute("aria-invalid", "true");
+        input.classList.add("settings-input--invalid");
+        errorElement.textContent = message;
+        errorElement.classList.remove("hidden");
+    }
+
+    function clearFieldError(input, errorElement) {
+        if (!input || !errorElement) return;
+
+        input.removeAttribute("aria-invalid");
+        input.classList.remove("settings-input--invalid");
+        errorElement.textContent = "";
+        errorElement.classList.add("hidden");
+    }
+
+    function showFormMessage(message) {
+        if (!formMessage) return;
+
+        formMessage.textContent = message;
+        formMessage.classList.remove("hidden");
+        formMessage.classList.add("form-message--error");
+    }
+
+    function clearFormMessage() {
+        if (!formMessage) return;
+
+        formMessage.textContent = "";
+        formMessage.classList.add("hidden");
+        formMessage.classList.remove("form-message--error");
+    }
+
+    function updateSubmitState() {
+        const hasIdentifier = Boolean(identifierInput.value.trim());
+        const hasPassword = Boolean(passwordInput.value.trim());
+        const isDisabled = !hasIdentifier || !hasPassword;
+
+        submitButton.disabled = isDisabled;
+        submitButton.setAttribute("aria-disabled", isDisabled ? "true" : "false");
+    }
+
+    function validateForm() {
+        let isValid = true;
+        clearFormMessage();
+
+        if (!identifierInput.value.trim()) {
+            showFieldError(identifierInput, identifierError, "Email or username is required");
+            isValid = false;
+        } else {
+            clearFieldError(identifierInput, identifierError);
+        }
+
+        if (!passwordInput.value.trim()) {
+            showFieldError(passwordInput, passwordError, "Password is required");
+            isValid = false;
+        } else {
+            clearFieldError(passwordInput, passwordError);
+        }
+
+        updateSubmitState();
+        return isValid;
+    }
+
+    [identifierInput, passwordInput].forEach(input => {
+        input.addEventListener("input", () => {
+            if (input === identifierInput) {
+                clearFieldError(identifierInput, identifierError);
+            } else {
+                clearFieldError(passwordInput, passwordError);
+            }
+
+            clearFormMessage();
+            updateSubmitState();
+        });
+    });
+
+    form.addEventListener("submit", event => {
+        if (!validateForm()) {
+            event.preventDefault();
+            showFormMessage("Fill in both required fields before continuing.");
+        }
+    });
+
+    updateSubmitState();
+});

--- a/src/main/resources/static/js/productivity.js
+++ b/src/main/resources/static/js/productivity.js
@@ -163,6 +163,15 @@ document.addEventListener("DOMContentLoaded", () => {
         return dateFormatter.format(date);
     }
 
+    function containsForbiddenValue(value) {
+        const normalized = String(value)
+            .trim()
+            .replace(/\s+/g, " ")
+            .toLowerCase();
+
+        return normalized === "67" || normalized === "six seven";
+    }
+
     function syncStateFromStorage() {
         state.items = storageAdapter.load();
     }
@@ -347,6 +356,13 @@ document.addEventListener("DOMContentLoaded", () => {
             return;
         }
 
+        if (containsForbiddenValue(value)) {
+            markInvalid(input, true);
+            showFormMessage(type, "67 and six seven are not allowed here.");
+            input?.focus();
+            return;
+        }
+
         if (type === "todo") {
             storageAdapter.create("todo", {
                 text: value,
@@ -392,6 +408,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
         if (!nextValue) {
             markInvalid(editor, true);
+            showFormMessage(type, `Please enter a ${itemLabels[type]} before saving it.`);
+            editor.focus();
+            return;
+        }
+
+        if (containsForbiddenValue(nextValue)) {
+            markInvalid(editor, true);
+            showFormMessage(type, "67 and six seven are not allowed here.");
             editor.focus();
             return;
         }

--- a/src/main/resources/static/js/settings.js
+++ b/src/main/resources/static/js/settings.js
@@ -99,17 +99,44 @@ function showSettingsMessage(message, isError = true) {
 function validateSettingsDraft() {
     clearValidationState();
 
+    const rawDraft = {
+        pomodoro: String(pomodoroInput.value ?? "").trim(),
+        shortBreak: String(shortBreakInput.value ?? "").trim(),
+        longBreak: String(longBreakInput.value ?? "").trim(),
+        focusCycles: String(focusCyclesInput.value ?? "").trim()
+    };
+
     const draft = {
-        pomodoro: Number(pomodoroInput.value),
-        shortBreak: Number(shortBreakInput.value),
-        longBreak: Number(longBreakInput.value),
+        pomodoro: Number(rawDraft.pomodoro),
+        shortBreak: Number(rawDraft.shortBreak),
+        longBreak: Number(rawDraft.longBreak),
         soundEnabled: soundEnabledInput.checked,
-        focusCycles: Number(focusCyclesInput.value)
+        focusCycles: Number(rawDraft.focusCycles)
     };
 
     for (const { input, key, label, min, max } of fieldConfig) {
+        const rawValue = rawDraft[key];
         const value = draft[key];
-        if (!Number.isInteger(value) || value < min || value > max) {
+
+        if (!rawValue) {
+            showValidationError(`${label} is required.`, [input]);
+            input.focus();
+            return null;
+        }
+
+        if (Number.isNaN(value)) {
+            showValidationError(`${label} must be a number.`, [input]);
+            input.focus();
+            return null;
+        }
+
+        if (!Number.isInteger(value)) {
+            showValidationError(`${label} must be a whole number.`, [input]);
+            input.focus();
+            return null;
+        }
+
+        if (value < min || value > max) {
             showValidationError(`${label} must be between ${min} and ${max}.`, [input]);
             input.focus();
             return null;

--- a/src/main/resources/static/js/user-settings.js
+++ b/src/main/resources/static/js/user-settings.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+    const MIN_PASSWORD_LENGTH = 8;
     const usernameForm = document.querySelector("#username-form");
     const passwordForm = document.querySelector("#password-form");
     const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
@@ -11,20 +12,121 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const usernameMessage = document.querySelector("#username-message");
     const passwordMessage = document.querySelector("#password-message");
+    const usernameError = document.querySelector('[data-error-for="username"]');
+    const oldPasswordError = document.querySelector('[data-error-for="oldPassword"]');
+    const newPasswordError = document.querySelector('[data-error-for="newPassword"]');
+    const confirmNewPasswordError = document.querySelector('[data-error-for="confirmNewPassword"]');
+
+    function showFieldError(input, errorElement, message) {
+        if (!input || !errorElement) return;
+
+        input.setAttribute("aria-invalid", "true");
+        input.classList.add("settings-input--invalid");
+        errorElement.textContent = message;
+        errorElement.classList.remove("hidden");
+    }
+
+    function clearFieldError(input, errorElement) {
+        if (!input || !errorElement) return;
+
+        input.removeAttribute("aria-invalid");
+        input.classList.remove("settings-input--invalid");
+        errorElement.textContent = "";
+        errorElement.classList.add("hidden");
+    }
+
+    function clearMessage(element) {
+        if (!element) return;
+
+        element.textContent = "";
+        element.classList.add("hidden");
+        element.classList.remove("form-message--success", "form-message--error");
+        element.style.color = "";
+    }
+
+    function validateUsername() {
+        const username = usernameInput.value.trim();
+        clearFieldError(usernameInput, usernameError);
+
+        if (!username) {
+            showFieldError(usernameInput, usernameError, "Username cannot be empty");
+            return false;
+        }
+
+        return true;
+    }
+
+    function validatePasswordForm() {
+        const oldPassword = oldPasswordInput.value;
+        const newPassword = newPasswordInput.value;
+        const confirmNewPassword = confirmNewPasswordInput.value;
+
+        clearFieldError(oldPasswordInput, oldPasswordError);
+        clearFieldError(newPasswordInput, newPasswordError);
+        clearFieldError(confirmNewPasswordInput, confirmNewPasswordError);
+
+        let isValid = true;
+
+        if (!oldPassword) {
+            showFieldError(oldPasswordInput, oldPasswordError, "Current password is required");
+            isValid = false;
+        }
+
+        if (!newPassword) {
+            showFieldError(newPasswordInput, newPasswordError, "New password is required");
+            isValid = false;
+        } else if (newPassword.length < MIN_PASSWORD_LENGTH) {
+            showFieldError(newPasswordInput, newPasswordError, `New password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+            isValid = false;
+        }
+
+        if (!confirmNewPassword) {
+            showFieldError(confirmNewPasswordInput, confirmNewPasswordError, "Confirm password is required");
+            isValid = false;
+        } else if (newPassword && confirmNewPassword !== newPassword) {
+            showFieldError(confirmNewPasswordInput, confirmNewPasswordError, "Passwords do not match");
+            isValid = false;
+        }
+
+        return isValid;
+    }
+
+    usernameInput?.addEventListener("input", () => {
+        clearFieldError(usernameInput, usernameError);
+        clearMessage(usernameMessage);
+    });
+
+    [oldPasswordInput, newPasswordInput, confirmNewPasswordInput].forEach(input => {
+        input?.addEventListener("input", () => {
+            if (input === oldPasswordInput) {
+                clearFieldError(oldPasswordInput, oldPasswordError);
+            }
+            if (input === newPasswordInput) {
+                clearFieldError(newPasswordInput, newPasswordError);
+                clearFieldError(confirmNewPasswordInput, confirmNewPasswordError);
+            }
+            if (input === confirmNewPasswordInput) {
+                clearFieldError(confirmNewPasswordInput, confirmNewPasswordError);
+            }
+
+            clearMessage(passwordMessage);
+        });
+    });
 
     if (usernameForm) {
         usernameForm.addEventListener("submit", async (event) => {
             event.preventDefault();
 
             const username = usernameInput.value.trim();
+            clearMessage(usernameMessage);
 
-            if (!username) {
+            if (!validateUsername()) {
                 showMessage(usernameMessage, "Username cannot be empty", false);
                 return;
             }
 
             try {
-                const response = await fetch("/api/user/username", {
+                const response = await window.fetch("/api/user/username", {
                     method: "PATCH",
                     headers: {
                         "Content-Type": "application/json",
@@ -42,6 +144,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     showMessage(usernameMessage, data.message || "Failed to update username", false);
                 }
             } catch (error) {
+                console.warn("Failed to update username from profile page.", error);
                 showMessage(usernameMessage, "Server error while updating username", false);
             }
         });
@@ -50,18 +153,19 @@ document.addEventListener("DOMContentLoaded", () => {
     if (passwordForm) {
         passwordForm.addEventListener("submit", async (event) => {
             event.preventDefault();
+            clearMessage(passwordMessage);
+
+            if (!validatePasswordForm()) {
+                showMessage(passwordMessage, "Fix the highlighted password fields", false);
+                return;
+            }
 
             const oldPassword = oldPasswordInput.value;
             const newPassword = newPasswordInput.value;
             const confirmNewPassword = confirmNewPasswordInput.value;
 
-            if (!oldPassword || !newPassword || !confirmNewPassword) {
-                showMessage(passwordMessage, "All password fields are required", false);
-                return;
-            }
-
             try {
-                const response = await fetch("/api/user/password", {
+                const response = await window.fetch("/api/user/password", {
                     method: "PATCH",
                     headers: {
                         "Content-Type": "application/json",
@@ -83,6 +187,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     showMessage(passwordMessage, data.message || "Failed to update password", false);
                 }
             } catch (error) {
+                console.warn("Failed to update password from profile page.", error);
                 showMessage(passwordMessage, "Server error while updating password", false);
             }
         });

--- a/src/main/resources/static/js/user-settings.js
+++ b/src/main/resources/static/js/user-settings.js
@@ -132,7 +132,8 @@ document.addEventListener("DOMContentLoaded", () => {
             clearMessage(usernameMessage);
 
             if (!validateUsername()) {
-                showMessage(usernameMessage, "Username cannot be empty", false);
+                const validationMessage = usernameError?.textContent?.trim() || "Username cannot be empty";
+                showMessage(usernameMessage, validationMessage, false);
                 return;
             }
 

--- a/src/main/resources/static/js/user-settings.js
+++ b/src/main/resources/static/js/user-settings.js
@@ -1,5 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
     const MIN_PASSWORD_LENGTH = 8;
+    const FORBIDDEN_VALUE_MESSAGE = "67 and six seven are not allowed here";
     const usernameForm = document.querySelector("#username-form");
     const passwordForm = document.querySelector("#password-form");
     const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
@@ -44,12 +45,22 @@ document.addEventListener("DOMContentLoaded", () => {
         element.style.color = "";
     }
 
+    function hasForbiddenUsername(value) {
+        const normalized = value.trim().replace(/\s+/g, " ").toLowerCase();
+        return normalized === "67" || normalized === "six seven";
+    }
+
     function validateUsername() {
         const username = usernameInput.value.trim();
         clearFieldError(usernameInput, usernameError);
 
         if (!username) {
             showFieldError(usernameInput, usernameError, "Username cannot be empty");
+            return false;
+        }
+
+        if (hasForbiddenUsername(username)) {
+            showFieldError(usernameInput, usernameError, FORBIDDEN_VALUE_MESSAGE);
             return false;
         }
 

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -42,5 +42,6 @@
     <th:block th:replace="~{fragments/footer :: footer}"></th:block>
 
     <th:block th:replace="~{fragments/mini-timer-scripts :: scripts}"></th:block>
+    <script th:src="@{/js/login-validation.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -23,7 +23,7 @@
 
                 <div class="profile-grid">
                     <form id="username-form" class="auth-form profile-panel" novalidate>
-                        <h3 class="profile-panel-title">Public Profile</h3>
+                        <h3 class="profile-panel-title">Profile Data</h3>
 
                         <div class="auth-field">
                             <label class="settings-label" for="username">Username</label>
@@ -37,7 +37,7 @@
                     </form>
 
                     <form id="password-form" class="auth-form profile-panel" novalidate>
-                        <h3 class="profile-panel-title">Security</h3>
+                        <h3 class="profile-panel-title">Change Password</h3>
 
                         <div class="auth-field">
                             <label class="settings-label" for="oldPassword">Current Password</label>

--- a/src/test/java/com/example/telos/api/AuthJwtControllerTest.java
+++ b/src/test/java/com/example/telos/api/AuthJwtControllerTest.java
@@ -8,6 +8,7 @@ import com.example.telos.security.JwtService;
 import com.example.telos.security.RestAccessDeniedHandler;
 import com.example.telos.security.RestAuthenticationEntryPoint;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.Map;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         JwtFilter.class,
         JwtApiWebMvcTestConfig.class
 })
+@Tag("contract")
 class AuthJwtControllerTest {
 
     @Autowired
@@ -99,5 +102,59 @@ class AuthJwtControllerTest {
                 .andExpect(jsonPath("$.path").value("/api/jwt/auth/login"))
                 .andExpect(jsonPath("$.method").value("POST"))
                 .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectBlankJwtLoginFieldValues() throws Exception {
+        mockMvc.perform(post("/api/jwt/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "login": "   ",
+                                  "password": "test-password"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("login cannot be empty"));
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectForbidden67JwtLoginIdentifier() throws Exception {
+        mockMvc.perform(post("/api/jwt/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "login": "six seven",
+                                  "password": "test-password"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("67 and six seven are not allowed here"));
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectMalformedJwtLoginBody() throws Exception {
+        mockMvc.perform(post("/api/jwt/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "login":
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MALFORMED_BODY"));
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectUnsupportedMethodForJwtLoginEndpoint() throws Exception {
+        mockMvc.perform(patch("/api/jwt/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isMethodNotAllowed());
     }
 }

--- a/src/test/java/com/example/telos/api/AuthJwtControllerTest.java
+++ b/src/test/java/com/example/telos/api/AuthJwtControllerTest.java
@@ -1,0 +1,103 @@
+package com.example.telos.api;
+
+import com.example.telos.controller.api.jwt.AuthJwtController;
+import com.example.telos.exception.RestExceptionHandler;
+import com.example.telos.model.User;
+import com.example.telos.security.JwtFilter;
+import com.example.telos.security.JwtService;
+import com.example.telos.security.RestAccessDeniedHandler;
+import com.example.telos.security.RestAuthenticationEntryPoint;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthJwtController.class)
+@Import({
+        RestExceptionHandler.class,
+        RestAuthenticationEntryPoint.class,
+        RestAccessDeniedHandler.class,
+        JwtFilter.class,
+        JwtApiWebMvcTestConfig.class
+})
+class AuthJwtControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SessionApiWebMvcTestConfig.StubUserService userService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        userService.reset();
+
+        User user = new User();
+        user.setEmail("user@test.com");
+        user.setUsername("demo-user");
+        user.setPassword("encoded-password");
+        userService.lookupUser = user;
+    }
+
+    @Test
+    void shouldReturnJwtTokenForValidCredentials() throws Exception {
+        MvcResult result = mockMvc.perform(post("/api/jwt/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "login": "user@test.com",
+                                  "password": "test-password"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isString())
+                .andReturn();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                Map.class
+        );
+
+        String token = String.valueOf(body.get("token"));
+        if (!"user@test.com".equals(jwtService.extractLogin(token))) {
+            throw new AssertionError("JWT token subject does not match expected user email");
+        }
+    }
+
+    @Test
+    void shouldReturnUnauthorizedForInvalidJwtLoginCredentials() throws Exception {
+        mockMvc.perform(post("/api/jwt/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "login": "user@test.com",
+                                  "password": "wrong-password"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Invalid login or password"))
+                .andExpect(jsonPath("$.path").value("/api/jwt/auth/login"))
+                .andExpect(jsonPath("$.method").value("POST"))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+}

--- a/src/test/java/com/example/telos/api/JwtApiWebMvcTestConfig.java
+++ b/src/test/java/com/example/telos/api/JwtApiWebMvcTestConfig.java
@@ -1,0 +1,122 @@
+package com.example.telos.api;
+
+import com.example.telos.security.JwtFilter;
+import com.example.telos.security.JwtService;
+import com.example.telos.security.RestAccessDeniedHandler;
+import com.example.telos.security.RestAuthenticationEntryPoint;
+import com.example.telos.service.LogErrorService;
+import com.example.telos.service.UserService;
+import com.example.telos.service.UserTimeSettingsService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.Base64;
+import java.util.List;
+
+@TestConfiguration
+class JwtApiWebMvcTestConfig {
+
+    @Bean
+    SecurityFilterChain jwtApiSecurityFilterChain(HttpSecurity http,
+                                                  JwtFilter jwtFilter,
+                                                  RestAuthenticationEntryPoint restAuthenticationEntryPoint,
+                                                  RestAccessDeniedHandler restAccessDeniedHandler) throws Exception {
+        http
+                .securityMatcher("/api/jwt/**")
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/jwt/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(restAuthenticationEntryPoint)
+                        .accessDeniedHandler(restAccessDeniedHandler)
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    LogErrorService logErrorService() {
+        return new NoOpLogErrorService();
+    }
+
+    @Bean
+    SessionApiWebMvcTestConfig.StubUserService stubUserService() {
+        return new SessionApiWebMvcTestConfig.StubUserService();
+    }
+
+    @Bean
+    UserService userService(SessionApiWebMvcTestConfig.StubUserService stubUserService) {
+        return stubUserService;
+    }
+
+    @Bean
+    SessionApiWebMvcTestConfig.StubUserTimeSettingsService stubUserTimeSettingsService() {
+        return new SessionApiWebMvcTestConfig.StubUserTimeSettingsService();
+    }
+
+    @Bean
+    UserTimeSettingsService userTimeSettingsService(SessionApiWebMvcTestConfig.StubUserTimeSettingsService stubUserTimeSettingsService) {
+        return stubUserTimeSettingsService;
+    }
+
+    @Bean
+    JwtService jwtService() {
+        String secret = Base64.getEncoder()
+                .encodeToString("01234567890123456789012345678901".getBytes());
+        return new JwtService(secret, 3_600_000);
+    }
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailsManager(
+                org.springframework.security.core.userdetails.User.withUsername("user@test.com")
+                        .password("{noop}test-password")
+                        .roles("USER")
+                        .build()
+        );
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager() {
+        return authentication -> {
+            String login = String.valueOf(authentication.getPrincipal());
+            String password = String.valueOf(authentication.getCredentials());
+
+            if ("user@test.com".equals(login) && "test-password".equals(password)) {
+                return new UsernamePasswordAuthenticationToken(
+                        login,
+                        password,
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                );
+            }
+
+            throw new BadCredentialsException("Invalid login or password");
+        };
+    }
+
+    static final class NoOpLogErrorService implements LogErrorService {
+        @Override
+        public void logWarn(HttpServletRequest request, HttpStatus httpStatus, Exception exception) {
+        }
+
+        @Override
+        public void logError(HttpServletRequest request, HttpStatus httpStatus, Exception exception) {
+        }
+    }
+}

--- a/src/test/java/com/example/telos/api/SessionApiWebMvcTestConfig.java
+++ b/src/test/java/com/example/telos/api/SessionApiWebMvcTestConfig.java
@@ -1,0 +1,242 @@
+package com.example.telos.api;
+
+import com.example.telos.dto.UserPasswordDto;
+import com.example.telos.dto.UserPasswordResponseDto;
+import com.example.telos.dto.UserTimeSettingsDto;
+import com.example.telos.dto.UserTimeSettingsResponseDto;
+import com.example.telos.dto.UserUsernameResponseDto;
+import com.example.telos.model.User;
+import com.example.telos.model.UserTimeSettings;
+import com.example.telos.security.JwtService;
+import com.example.telos.security.RestAccessDeniedHandler;
+import com.example.telos.security.RestAuthenticationEntryPoint;
+import com.example.telos.service.LogErrorService;
+import com.example.telos.service.UserService;
+import com.example.telos.service.UserTimeSettingsService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import java.util.Base64;
+import java.util.List;
+
+@TestConfiguration
+class SessionApiWebMvcTestConfig {
+
+    @Bean
+    SecurityFilterChain sessionApiSecurityFilterChain(HttpSecurity http,
+                                                      RestAuthenticationEntryPoint restAuthenticationEntryPoint,
+                                                      RestAccessDeniedHandler restAccessDeniedHandler) throws Exception {
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .exceptionHandling(ex -> ex
+                        .defaultAuthenticationEntryPointFor(
+                                restAuthenticationEntryPoint,
+                                request -> request.getRequestURI().startsWith("/api/")
+                        )
+                        .defaultAccessDeniedHandlerFor(
+                                restAccessDeniedHandler,
+                                request -> request.getRequestURI().startsWith("/api/")
+                        )
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    LogErrorService logErrorService() {
+        return new NoOpLogErrorService();
+    }
+
+    @Bean
+    JwtService jwtService() {
+        String secret = Base64.getEncoder()
+                .encodeToString("01234567890123456789012345678901".getBytes());
+        return new JwtService(secret, 3_600_000);
+    }
+
+    @Bean
+    UserDetailsService userDetailsService() {
+        return new InMemoryUserDetailsManager(
+                org.springframework.security.core.userdetails.User.withUsername("user@test.com")
+                        .password("{noop}test-password")
+                        .roles("USER")
+                        .build()
+        );
+    }
+
+    @Bean
+    StubUserService stubUserService() {
+        return new StubUserService();
+    }
+
+    @Bean
+    UserService userService(StubUserService stubUserService) {
+        return stubUserService;
+    }
+
+    @Bean
+    StubUserTimeSettingsService stubUserTimeSettingsService() {
+        return new StubUserTimeSettingsService();
+    }
+
+    @Bean
+    UserTimeSettingsService userTimeSettingsService(StubUserTimeSettingsService stubUserTimeSettingsService) {
+        return stubUserTimeSettingsService;
+    }
+
+    static final class NoOpLogErrorService implements LogErrorService {
+        @Override
+        public void logWarn(HttpServletRequest request, HttpStatus httpStatus, Exception exception) {
+        }
+
+        @Override
+        public void logError(HttpServletRequest request, HttpStatus httpStatus, Exception exception) {
+        }
+    }
+
+    static final class StubUserService implements UserService {
+        UserUsernameResponseDto nextUsernameResponse = new UserUsernameResponseDto("default-user", "Username updated");
+        UserPasswordResponseDto nextPasswordResponse = new UserPasswordResponseDto("Password updated");
+        User lookupUser;
+        RuntimeException usernameException;
+        RuntimeException passwordException;
+
+        void reset() {
+            nextUsernameResponse = new UserUsernameResponseDto("default-user", "Username updated");
+            nextPasswordResponse = new UserPasswordResponseDto("Password updated");
+            lookupUser = null;
+            usernameException = null;
+            passwordException = null;
+        }
+
+        @Override
+        public User findById(Long id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public User findByEmail(String email) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public User findByUsername(String username) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public User create(User user) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public User update(User newUser) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void delete(User user) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public User findByEmailOrUsername(String login) {
+            if (lookupUser != null) {
+                return lookupUser;
+            }
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<User> findAll() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UserUsernameResponseDto updateUsername(String login, String username) {
+            if (usernameException != null) {
+                throw usernameException;
+            }
+            return nextUsernameResponse;
+        }
+
+        @Override
+        public UserPasswordResponseDto updatePassword(String login, UserPasswordDto userPasswordDto) {
+            if (passwordException != null) {
+                throw passwordException;
+            }
+            return nextPasswordResponse;
+        }
+    }
+
+    static final class StubUserTimeSettingsService implements UserTimeSettingsService {
+        UserTimeSettingsResponseDto nextFindSettingsResponse =
+                new UserTimeSettingsResponseDto(25, 5, 15, 4, true, "Settings loaded");
+        UserTimeSettingsResponseDto nextUpdateSettingsResponse =
+                new UserTimeSettingsResponseDto(30, 7, 20, 3, false, "Settings updated");
+        RuntimeException findException;
+        RuntimeException updateException;
+
+        void reset() {
+            nextFindSettingsResponse = new UserTimeSettingsResponseDto(25, 5, 15, 4, true, "Settings loaded");
+            nextUpdateSettingsResponse = new UserTimeSettingsResponseDto(30, 7, 20, 3, false, "Settings updated");
+            findException = null;
+            updateException = null;
+        }
+
+        @Override
+        public UserTimeSettings findById(Long userTimeSettingsId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UserTimeSettings create(UserTimeSettings userTimeSettings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UserTimeSettings update(UserTimeSettings newUserTimeSettings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void delete(UserTimeSettings userTimeSettings) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UserTimeSettings findByUser(User user) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<UserTimeSettings> findAll() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UserTimeSettingsResponseDto updateSettings(String login, UserTimeSettingsDto userTimeSettingsDto) {
+            if (updateException != null) {
+                throw updateException;
+            }
+            return nextUpdateSettingsResponse;
+        }
+
+        @Override
+        public UserTimeSettingsResponseDto findSettings(String login) {
+            if (findException != null) {
+                throw findException;
+            }
+            return nextFindSettingsResponse;
+        }
+    }
+}

--- a/src/test/java/com/example/telos/api/UserJwtControllerTest.java
+++ b/src/test/java/com/example/telos/api/UserJwtControllerTest.java
@@ -12,6 +12,7 @@ import com.example.telos.security.JwtService;
 import com.example.telos.security.RestAccessDeniedHandler;
 import com.example.telos.security.RestAuthenticationEntryPoint;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -35,6 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         JwtFilter.class,
         JwtApiWebMvcTestConfig.class
 })
+@Tag("contract")
 class UserJwtControllerTest {
 
     @Autowired
@@ -111,6 +114,22 @@ class UserJwtControllerTest {
     }
 
     @Test
+    @Tag("negative")
+    void shouldRejectForbidden67JwtUsernameUpdate() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/username")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "67"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("67 and six seven are not allowed here"));
+    }
+
+    @Test
     void shouldUpdatePasswordWithValidJwt() throws Exception {
         mockMvc.perform(patch("/api/jwt/user/password")
                         .header("Authorization", bearerToken)
@@ -143,6 +162,24 @@ class UserJwtControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.errorCode").value("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectShortJwtPasswordAtValidationLayer() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/password")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "short",
+                                  "confirmNewPassword": "short"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("newPassword must be at least 8 characters"));
     }
 
     @Test
@@ -200,5 +237,13 @@ class UserJwtControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.status").value(401))
                 .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectUnsupportedMethodForJwtUsernameEndpoint() throws Exception {
+        mockMvc.perform(post("/api/jwt/user/username")
+                        .header("Authorization", bearerToken))
+                .andExpect(status().isMethodNotAllowed());
     }
 }

--- a/src/test/java/com/example/telos/api/UserJwtControllerTest.java
+++ b/src/test/java/com/example/telos/api/UserJwtControllerTest.java
@@ -1,0 +1,204 @@
+package com.example.telos.api;
+
+import com.example.telos.controller.api.jwt.UserJwtController;
+import com.example.telos.controller.api.jwt.UserTimeSettingsJwtController;
+import com.example.telos.dto.UserPasswordResponseDto;
+import com.example.telos.dto.UserTimeSettingsResponseDto;
+import com.example.telos.dto.UserUsernameResponseDto;
+import com.example.telos.exception.RestExceptionHandler;
+import com.example.telos.exception.UsernameAlreadyTakenException;
+import com.example.telos.security.JwtFilter;
+import com.example.telos.security.JwtService;
+import com.example.telos.security.RestAccessDeniedHandler;
+import com.example.telos.security.RestAuthenticationEntryPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({
+        UserJwtController.class,
+        UserTimeSettingsJwtController.class
+})
+@Import({
+        RestExceptionHandler.class,
+        RestAuthenticationEntryPoint.class,
+        RestAccessDeniedHandler.class,
+        JwtFilter.class,
+        JwtApiWebMvcTestConfig.class
+})
+class UserJwtControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SessionApiWebMvcTestConfig.StubUserService userService;
+
+    @Autowired
+    private SessionApiWebMvcTestConfig.StubUserTimeSettingsService userTimeSettingsService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    private String bearerToken;
+
+    @BeforeEach
+    void setUp() {
+        userService.reset();
+        userTimeSettingsService.reset();
+        userService.nextUsernameResponse = new UserUsernameResponseDto("jwt-user", "Username updated");
+        userService.nextPasswordResponse = new UserPasswordResponseDto("Password updated");
+        userTimeSettingsService.nextFindSettingsResponse =
+                new UserTimeSettingsResponseDto(25, 5, 15, 4, true, "Settings loaded");
+        userTimeSettingsService.nextUpdateSettingsResponse =
+                new UserTimeSettingsResponseDto(35, 10, 25, 2, false, "Settings updated");
+        bearerToken = "Bearer " + jwtService.generateToken("user@test.com");
+    }
+
+    @Test
+    void shouldRejectAnonymousJwtUsernameUpdate() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/username")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "jwt-user"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void shouldUpdateUsernameWithValidJwt() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/username")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "jwt-user"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("jwt-user"))
+                .andExpect(jsonPath("$.message").value("Username updated"));
+    }
+
+    @Test
+    void shouldReturnConflictForJwtUsernameUpdate() throws Exception {
+        userService.usernameException = new UsernameAlreadyTakenException("Username is already taken");
+
+        mockMvc.perform(patch("/api/jwt/user/username")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "taken-name"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.errorCode").value("USERNAME_CONFLICT"));
+    }
+
+    @Test
+    void shouldUpdatePasswordWithValidJwt() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/password")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "new-password-123",
+                                  "confirmNewPassword": "new-password-123"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password updated"));
+    }
+
+    @Test
+    void shouldRejectInvalidJwtPasswordUpdate() throws Exception {
+        userService.passwordException = new IllegalArgumentException("New passwords do not match");
+
+        mockMvc.perform(patch("/api/jwt/user/password")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "new-password-123",
+                                  "confirmNewPassword": "different-password"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    void shouldReturnTimeSettingsWithValidJwt() throws Exception {
+        mockMvc.perform(get("/api/jwt/user/time-settings")
+                        .header("Authorization", bearerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pomodoroMinutes").value(25))
+                .andExpect(jsonPath("$.message").value("Settings loaded"));
+    }
+
+    @Test
+    void shouldUpdateTimeSettingsWithValidJwt() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/time-settings")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 35,
+                                  "shortBreakMinutes": 10,
+                                  "longBreakMinutes": 25,
+                                  "pomoCycles": 2,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pomodoroMinutes").value(35))
+                .andExpect(jsonPath("$.soundsEnabled").value(false))
+                .andExpect(jsonPath("$.message").value("Settings updated"));
+    }
+
+    @Test
+    void shouldRejectInvalidJwtTimeSettingsPayload() throws Exception {
+        mockMvc.perform(patch("/api/jwt/user/time-settings")
+                        .header("Authorization", bearerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 0,
+                                  "shortBreakMinutes": 10,
+                                  "longBreakMinutes": 25,
+                                  "pomoCycles": 2,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void shouldRejectInvalidJwtToken() throws Exception {
+        mockMvc.perform(get("/api/jwt/user/time-settings")
+                        .header("Authorization", "Bearer invalid-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+}

--- a/src/test/java/com/example/telos/api/UserRestControllerTest.java
+++ b/src/test/java/com/example/telos/api/UserRestControllerTest.java
@@ -1,0 +1,217 @@
+package com.example.telos.api;
+
+import com.example.telos.controller.api.session.UserRestController;
+import com.example.telos.dto.UserPasswordResponseDto;
+import com.example.telos.dto.UserUsernameResponseDto;
+import com.example.telos.exception.RestExceptionHandler;
+import com.example.telos.exception.UsernameAlreadyTakenException;
+import com.example.telos.security.RestAccessDeniedHandler;
+import com.example.telos.security.RestAuthenticationEntryPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserRestController.class)
+@Import({
+        RestExceptionHandler.class,
+        RestAuthenticationEntryPoint.class,
+        RestAccessDeniedHandler.class,
+        SessionApiWebMvcTestConfig.class
+})
+class UserRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SessionApiWebMvcTestConfig.StubUserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService.reset();
+    }
+
+    @Test
+    void shouldReturnJsonUnauthorizedForAnonymousUsernameUpdate() throws Exception {
+        mockMvc.perform(patch("/api/user/username")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "new-name"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.path").value("/api/user/username"))
+                .andExpect(jsonPath("$.method").value("PATCH"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldUpdateUsernameForAuthenticatedUser() throws Exception {
+        userService.nextUsernameResponse = new UserUsernameResponseDto("new-name", "Username updated");
+
+        mockMvc.perform(patch("/api/user/username")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "new-name"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("new-name"))
+                .andExpect(jsonPath("$.message").value("Username updated"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectBlankUsername() throws Exception {
+        mockMvc.perform(patch("/api/user/username")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "   "
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("username cannot be empty"))
+                .andExpect(jsonPath("$.path").value("/api/user/username"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldReturnConflictWhenUsernameAlreadyExists() throws Exception {
+        userService.usernameException = new UsernameAlreadyTakenException("Username is already taken");
+
+        mockMvc.perform(patch("/api/user/username")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "taken-name"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.error").value("Conflict"))
+                .andExpect(jsonPath("$.message").value("Username is already taken"))
+                .andExpect(jsonPath("$.path").value("/api/user/username"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("USERNAME_CONFLICT"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectUsernameUpdateWithoutCsrf() throws Exception {
+        mockMvc.perform(patch("/api/user/username")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "new-name"
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldUpdatePasswordForAuthenticatedUser() throws Exception {
+        userService.nextPasswordResponse = new UserPasswordResponseDto("Password updated");
+
+        mockMvc.perform(patch("/api/user/password")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "new-password-123",
+                                  "confirmNewPassword": "new-password-123"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password updated"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectBlankPasswordFields() throws Exception {
+        mockMvc.perform(patch("/api/user/password")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "",
+                                  "newPassword": "new-password-123",
+                                  "confirmNewPassword": "new-password-123"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("oldPassword cannot be empty"))
+                .andExpect(jsonPath("$.path").value("/api/user/password"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldReturnBadRequestWhenPasswordUpdateFailsBusinessValidation() throws Exception {
+        userService.passwordException = new IllegalArgumentException("New passwords do not match");
+
+        mockMvc.perform(patch("/api/user/password")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "new-password-123",
+                                  "confirmNewPassword": "different-password"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("New passwords do not match"))
+                .andExpect(jsonPath("$.path").value("/api/user/password"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("INVALID_ARGUMENT"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectPasswordUpdateWithoutCsrf() throws Exception {
+        mockMvc.perform(patch("/api/user/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "new-password-123",
+                                  "confirmNewPassword": "new-password-123"
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+    }
+}

--- a/src/test/java/com/example/telos/api/UserRestControllerTest.java
+++ b/src/test/java/com/example/telos/api/UserRestControllerTest.java
@@ -8,6 +8,7 @@ import com.example.telos.exception.UsernameAlreadyTakenException;
 import com.example.telos.security.RestAccessDeniedHandler;
 import com.example.telos.security.RestAuthenticationEntryPoint;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -17,6 +18,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         RestAccessDeniedHandler.class,
         SessionApiWebMvcTestConfig.class
 })
+@Tag("contract")
 class UserRestControllerTest {
 
     @Autowired
@@ -134,6 +137,48 @@ class UserRestControllerTest {
     }
 
     @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectForbidden67Username() throws Exception {
+        mockMvc.perform(patch("/api/user/username")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": " SIX   seven "
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("67 and six seven are not allowed here"));
+    }
+
+    @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectMalformedUsernameBody() throws Exception {
+        mockMvc.perform(patch("/api/user/username")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username":
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MALFORMED_BODY"));
+    }
+
+    @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectUnsupportedMethodForUsernameEndpoint() throws Exception {
+        mockMvc.perform(post("/api/user/username")
+                        .with(csrf()))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
     @WithMockUser(username = "user@test.com")
     void shouldUpdatePasswordForAuthenticatedUser() throws Exception {
         userService.nextPasswordResponse = new UserPasswordResponseDto("Password updated");
@@ -172,6 +217,25 @@ class UserRestControllerTest {
                 .andExpect(jsonPath("$.path").value("/api/user/password"))
                 .andExpect(jsonPath("$.method").value("PATCH"))
                 .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectShortNewPasswordAtValidationLayer() throws Exception {
+        mockMvc.perform(patch("/api/user/password")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "oldPassword": "current-password",
+                                  "newPassword": "short",
+                                  "confirmNewPassword": "short"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.message").value("newPassword must be at least 8 characters"));
     }
 
     @Test

--- a/src/test/java/com/example/telos/api/UserTimeSettingsRestControllerTest.java
+++ b/src/test/java/com/example/telos/api/UserTimeSettingsRestControllerTest.java
@@ -4,8 +4,10 @@ import com.example.telos.controller.api.session.UserTimeSettingsRestController;
 import com.example.telos.exception.RestExceptionHandler;
 import com.example.telos.security.RestAccessDeniedHandler;
 import com.example.telos.security.RestAuthenticationEntryPoint;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -16,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         RestAccessDeniedHandler.class,
         SessionApiWebMvcTestConfig.class
 })
+@Tag("contract")
 class UserTimeSettingsRestControllerTest {
 
     @Autowired
@@ -153,5 +157,75 @@ class UserTimeSettingsRestControllerTest {
                 .andExpect(jsonPath("$.path").value("/api/user/time-settings"))
                 .andExpect(jsonPath("$.method").value("PATCH"))
                 .andExpect(jsonPath("$.errorCode").value("MALFORMED_BODY"));
+    }
+
+    @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectNonNumericTimeSettingsValue() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": "abc",
+                                  "shortBreakMinutes": 7,
+                                  "longBreakMinutes": 20,
+                                  "pomoCycles": 3,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MALFORMED_BODY"));
+    }
+
+    @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldCurrentlyCoerceDecimalTimeSettingsValueInsteadOfRejectingIt() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 25.5,
+                                  "shortBreakMinutes": 7,
+                                  "longBreakMinutes": 20,
+                                  "pomoCycles": 3,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Settings updated"));
+    }
+
+    @Test
+    @Tag("negative")
+    @Tag("known-gap")
+    @EnabledIfSystemProperty(named = "runKnownGaps", matches = "true")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectDecimalTimeSettingsValueWhenStrictIntegerValidationIsEnabled() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 25.5,
+                                  "shortBreakMinutes": 7,
+                                  "longBreakMinutes": 20,
+                                  "pomoCycles": 3,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Tag("negative")
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectUnsupportedMethodForTimeSettingsEndpoint() throws Exception {
+        mockMvc.perform(post("/api/user/time-settings")
+                        .with(csrf()))
+                .andExpect(status().isMethodNotAllowed());
     }
 }

--- a/src/test/java/com/example/telos/api/UserTimeSettingsRestControllerTest.java
+++ b/src/test/java/com/example/telos/api/UserTimeSettingsRestControllerTest.java
@@ -1,0 +1,157 @@
+package com.example.telos.api;
+
+import com.example.telos.controller.api.session.UserTimeSettingsRestController;
+import com.example.telos.exception.RestExceptionHandler;
+import com.example.telos.security.RestAccessDeniedHandler;
+import com.example.telos.security.RestAuthenticationEntryPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserTimeSettingsRestController.class)
+@Import({
+        RestExceptionHandler.class,
+        RestAuthenticationEntryPoint.class,
+        RestAccessDeniedHandler.class,
+        SessionApiWebMvcTestConfig.class
+})
+class UserTimeSettingsRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SessionApiWebMvcTestConfig.StubUserTimeSettingsService userTimeSettingsService;
+
+    @BeforeEach
+    void setUp() {
+        userTimeSettingsService.reset();
+    }
+
+    @Test
+    void shouldReturnJsonUnauthorizedForAnonymousGetTimeSettings() throws Exception {
+        mockMvc.perform(get("/api/user/time-settings"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Authentication is required to access this resource"))
+                .andExpect(jsonPath("$.path").value("/api/user/time-settings"))
+                .andExpect(jsonPath("$.method").value("GET"))
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldReturnTimeSettingsForAuthenticatedUser() throws Exception {
+        mockMvc.perform(get("/api/user/time-settings"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pomodoroMinutes").value(25))
+                .andExpect(jsonPath("$.shortBreakMinutes").value(5))
+                .andExpect(jsonPath("$.longBreakMinutes").value(15))
+                .andExpect(jsonPath("$.pomoCycles").value(4))
+                .andExpect(jsonPath("$.soundsEnabled").value(true))
+                .andExpect(jsonPath("$.message").value("Settings loaded"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldUpdateTimeSettingsForAuthenticatedUser() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 30,
+                                  "shortBreakMinutes": 7,
+                                  "longBreakMinutes": 20,
+                                  "pomoCycles": 3,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pomodoroMinutes").value(30))
+                .andExpect(jsonPath("$.shortBreakMinutes").value(7))
+                .andExpect(jsonPath("$.longBreakMinutes").value(20))
+                .andExpect(jsonPath("$.pomoCycles").value(3))
+                .andExpect(jsonPath("$.soundsEnabled").value(false))
+                .andExpect(jsonPath("$.message").value("Settings updated"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectTimeSettingsUpdateWithoutCsrf() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 30,
+                                  "shortBreakMinutes": 7,
+                                  "longBreakMinutes": 20,
+                                  "pomoCycles": 3,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.error").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("You do not have permission to perform this action"))
+                .andExpect(jsonPath("$.path").value("/api/user/time-settings"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectInvalidTimeSettingsPayload() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes": 0,
+                                  "shortBreakMinutes": 7,
+                                  "longBreakMinutes": 20,
+                                  "pomoCycles": 3,
+                                  "soundsEnabled": false
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("Work minutes must be at least 1 minute"))
+                .andExpect(jsonPath("$.path").value("/api/user/time-settings"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @WithMockUser(username = "user@test.com")
+    void shouldRejectMalformedTimeSettingsBody() throws Exception {
+        mockMvc.perform(patch("/api/user/time-settings")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "pomodoroMinutes":
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("Request body is missing or malformed"))
+                .andExpect(jsonPath("$.path").value("/api/user/time-settings"))
+                .andExpect(jsonPath("$.method").value("PATCH"))
+                .andExpect(jsonPath("$.errorCode").value("MALFORMED_BODY"));
+    }
+}

--- a/src/test/java/com/example/telos/controllerTests/AboutUsControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/AboutUsControllerTest.java
@@ -2,18 +2,14 @@ package com.example.telos.controllerTests;
 
 import com.example.telos.controller.page.AboutUsController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(AboutUsController.class)
 public class AboutUsControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc = MockMvcTestUtils.standalone(new AboutUsController());
 
     @Test
     void shouldReturnAboutPage() throws Exception {

--- a/src/test/java/com/example/telos/controllerTests/HelpUsControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/HelpUsControllerTest.java
@@ -3,18 +3,14 @@ package com.example.telos.controllerTests;
 
 import com.example.telos.controller.page.HelpUsController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(HelpUsController.class)
 public class HelpUsControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+    private final MockMvc mockMvc = MockMvcTestUtils.standalone(new HelpUsController());
 
     @Test
     void shouldReturnHelpUsPage() throws Exception{

--- a/src/test/java/com/example/telos/controllerTests/HomeControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/HomeControllerTest.java
@@ -2,18 +2,14 @@ package com.example.telos.controllerTests;
 
 import com.example.telos.controller.page.HomeController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(HomeController.class)
 public class HomeControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc = MockMvcTestUtils.standalone(new HomeController());
 
     @Test
     public void shouldReturnIndexPage() throws Exception {

--- a/src/test/java/com/example/telos/controllerTests/LoginControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/LoginControllerTest.java
@@ -2,19 +2,15 @@ package com.example.telos.controllerTests;
 
 import com.example.telos.controller.page.LoginController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@WebMvcTest(LoginController.class)
 public class LoginControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc = MockMvcTestUtils.standalone(new LoginController());
 
     @Test
     void shouldReturnLoginPage() throws Exception {

--- a/src/test/java/com/example/telos/controllerTests/MockMvcTestUtils.java
+++ b/src/test/java/com/example/telos/controllerTests/MockMvcTestUtils.java
@@ -1,0 +1,33 @@
+package com.example.telos.controllerTests;
+
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.view.AbstractView;
+
+import java.util.Map;
+
+public final class MockMvcTestUtils {
+
+    private MockMvcTestUtils() {
+    }
+
+    public static MockMvc standalone(Object controller) {
+        return MockMvcBuilders
+                .standaloneSetup(controller)
+                .setViewResolvers((viewName, locale) -> noopView())
+                .build();
+    }
+
+    private static View noopView() {
+        return new AbstractView() {
+            @Override
+            protected void renderMergedOutputModel(
+                    Map<String, Object> model,
+                    jakarta.servlet.http.HttpServletRequest request,
+                    jakarta.servlet.http.HttpServletResponse response
+            ) {
+            }
+        };
+    }
+}

--- a/src/test/java/com/example/telos/controllerTests/ProductivityControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/ProductivityControllerTest.java
@@ -2,19 +2,15 @@ package com.example.telos.controllerTests;
 
 import com.example.telos.controller.page.ProductivityController;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@WebMvcTest(ProductivityController.class)
 public class ProductivityControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc = MockMvcTestUtils.standalone(new ProductivityController());
 
     @Test
     void shouldReturnProductivityPage() throws Exception {

--- a/src/test/java/com/example/telos/controllerTests/UserControllerTest.java
+++ b/src/test/java/com/example/telos/controllerTests/UserControllerTest.java
@@ -1,25 +1,90 @@
 package com.example.telos.controllerTests;
 
 import com.example.telos.controller.page.UserController;
+import com.example.telos.dto.UserPasswordDto;
+import com.example.telos.dto.UserPasswordResponseDto;
+import com.example.telos.dto.UserUsernameResponseDto;
+import com.example.telos.model.User;
+import com.example.telos.service.UserService;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.security.Principal;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@WebMvcTest(UserController.class)
 public class UserControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc = MockMvcTestUtils.standalone(new UserController(new StubUserService()));
 
     @Test
     void shouldReturnUserPage() throws Exception {
-        mockMvc.perform(get("/user"))
+        mockMvc.perform(get("/user")
+                        .principal((Principal) () -> "user@test.com"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("user"));
+    }
+
+    private static final class StubUserService implements UserService {
+
+        @Override
+        public User findById(Long id) {
+            return buildUser("user@test.com", "demo-user");
+        }
+
+        @Override
+        public User findByEmail(String email) {
+            return buildUser(email, "demo-user");
+        }
+
+        @Override
+        public User findByUsername(String username) {
+            return buildUser("user@test.com", username);
+        }
+
+        @Override
+        public User create(User user) {
+            return user;
+        }
+
+        @Override
+        public User update(User newUser) {
+            return newUser;
+        }
+
+        @Override
+        public void delete(User user) {
+        }
+
+        @Override
+        public User findByEmailOrUsername(String login) {
+            return buildUser("user@test.com", "demo-user");
+        }
+
+        @Override
+        public List<User> findAll() {
+            return List.of(buildUser("user@test.com", "demo-user"));
+        }
+
+        @Override
+        public UserUsernameResponseDto updateUsername(String login, String username) {
+            return new UserUsernameResponseDto(username, "Username updated");
+        }
+
+        @Override
+        public UserPasswordResponseDto updatePassword(String login, UserPasswordDto userPasswordDto) {
+            return new UserPasswordResponseDto("Password updated");
+        }
+
+        private User buildUser(String email, String username) {
+            User user = new User();
+            user.setEmail(email);
+            user.setUsername(username);
+            user.setPassword("encoded-password");
+            return user;
+        }
     }
 }

--- a/src/test/java/com/example/telos/security/JwtFilterTest.java
+++ b/src/test/java/com/example/telos/security/JwtFilterTest.java
@@ -1,0 +1,182 @@
+package com.example.telos.security;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JwtFilterTest {
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtFilter jwtFilter;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldPassThroughWhenAuthorizationHeaderIsMissing() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(userDetailsService, never()).loadUserByUsername(any());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldPassThroughWhenAuthorizationHeaderIsNotBearer() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(userDetailsService, never()).loadUserByUsername(any());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldAuthenticateRequestWhenBearerTokenIsValid() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        UserDetails userDetails = User.withUsername("user@test.com")
+                .password("ignored")
+                .authorities("ROLE_USER")
+                .build();
+
+        when(jwtService.extractLogin("valid-token")).thenReturn("user@test.com");
+        when(userDetailsService.loadUserByUsername("user@test.com")).thenReturn(userDetails);
+        when(jwtService.isTokenValid("valid-token", userDetails)).thenReturn(true);
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(userDetailsService).loadUserByUsername("user@test.com");
+        assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+        assertEquals("user@test.com",
+                ((UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUsername());
+        assertTrue(SecurityContextHolder.getContext().getAuthentication().isAuthenticated());
+    }
+
+    @Test
+    void shouldNotOverwriteExistingAuthentication() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        UsernamePasswordAuthenticationToken existingAuth =
+                new UsernamePasswordAuthenticationToken("already-authenticated", null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(existingAuth);
+
+        when(jwtService.extractLogin("valid-token")).thenReturn("user@test.com");
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(userDetailsService, never()).loadUserByUsername(any());
+        verify(filterChain).doFilter(request, response);
+        assertEquals(existingAuth, SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldNotAuthenticateWhenTokenDoesNotMatchLoadedUser() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer valid-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        UserDetails userDetails = User.withUsername("user@test.com")
+                .password("ignored")
+                .authorities("ROLE_USER")
+                .build();
+
+        when(jwtService.extractLogin("valid-token")).thenReturn("user@test.com");
+        when(userDetailsService.loadUserByUsername("user@test.com")).thenReturn(userDetails);
+        when(jwtService.isTokenValid("valid-token", userDetails)).thenReturn(false);
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldInvokeEntryPointWhenJwtParsingFails() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer broken-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtService.extractLogin("broken-token")).thenThrow(new JwtException("Token is invalid"));
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        ArgumentCaptor<BadCredentialsException> exceptionCaptor = ArgumentCaptor.forClass(BadCredentialsException.class);
+        verify(restAuthenticationEntryPoint).commence(eq(request), eq(response), exceptionCaptor.capture());
+        verify(filterChain, never()).doFilter(request, response);
+        assertEquals("Invalid or expired token", exceptionCaptor.getValue().getMessage());
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    @Test
+    void shouldInvokeEntryPointWhenJwtHandlingThrowsIllegalArgumentException() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer broken-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtService.extractLogin("broken-token")).thenThrow(new IllegalArgumentException("Bad token"));
+
+        jwtFilter.doFilter(request, response, filterChain);
+
+        verify(restAuthenticationEntryPoint).commence(eq(request), eq(response), any(BadCredentialsException.class));
+        verify(filterChain, never()).doFilter(request, response);
+        assertNull(SecurityContextHolder.getContext().getAuthentication());
+    }
+}

--- a/src/test/java/com/example/telos/security/JwtServiceTest.java
+++ b/src/test/java/com/example/telos/security/JwtServiceTest.java
@@ -84,7 +84,7 @@ class JwtServiceTest {
                 .subject("user@test.com")
                 .issuedAt(new Date(pastTime - 1_000))
                 .expiration(new Date(pastTime))
-                .signWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(Base64.getDecoder().decode(VALID_SECRET)))
+                .signWith(buildKey(VALID_SECRET))
                 .compact();
 
         assertThrows(ExpiredJwtException.class, () -> jwtService.isTokenValid(token, userDetails));
@@ -111,9 +111,13 @@ class JwtServiceTest {
 
     private Claims parseClaims(String token, String secret) {
         return Jwts.parser()
-                .verifyWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret)))
+                .verifyWith(buildKey(secret))
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    private javax.crypto.SecretKey buildKey(String secret) {
+        return io.jsonwebtoken.security.Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
     }
 }

--- a/src/test/java/com/example/telos/security/JwtServiceTest.java
+++ b/src/test/java/com/example/telos/security/JwtServiceTest.java
@@ -72,15 +72,20 @@ class JwtServiceTest {
     }
 
     @Test
-    void shouldThrowForExpiredTokenValidation() throws InterruptedException {
-        JwtService jwtService = new JwtService(VALID_SECRET, 1);
+    void shouldThrowForExpiredTokenValidation() {
+        JwtService jwtService = new JwtService(VALID_SECRET, 3_600_000);
         UserDetails userDetails = User.withUsername("user@test.com")
                 .password("ignored")
                 .authorities("ROLE_USER")
                 .build();
 
-        String token = jwtService.generateToken("user@test.com");
-        Thread.sleep(20);
+        long pastTime = System.currentTimeMillis() - 10_000;
+        String token = Jwts.builder()
+                .subject("user@test.com")
+                .issuedAt(new Date(pastTime - 1_000))
+                .expiration(new Date(pastTime))
+                .signWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(Base64.getDecoder().decode(VALID_SECRET)))
+                .compact();
 
         assertThrows(ExpiredJwtException.class, () -> jwtService.isTokenValid(token, userDetails));
     }

--- a/src/test/java/com/example/telos/security/JwtServiceTest.java
+++ b/src/test/java/com/example/telos/security/JwtServiceTest.java
@@ -1,0 +1,114 @@
+package com.example.telos.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.WeakKeyException;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Base64;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtServiceTest {
+
+    private static final String VALID_SECRET = Base64.getEncoder()
+            .encodeToString("01234567890123456789012345678901".getBytes());
+
+    @Test
+    void shouldGenerateTokenWithExpectedSubjectAndClaims() {
+        JwtService jwtService = new JwtService(VALID_SECRET, 3_600_000);
+
+        String token = jwtService.generateToken("user@test.com");
+        Claims claims = parseClaims(token, VALID_SECRET);
+
+        assertNotNull(token);
+        assertEquals("user@test.com", claims.getSubject());
+        assertNotNull(claims.getIssuedAt());
+        assertNotNull(claims.getExpiration());
+        assertTrue(claims.getExpiration().after(claims.getIssuedAt()));
+    }
+
+    @Test
+    void shouldExtractLoginFromGeneratedToken() {
+        JwtService jwtService = new JwtService(VALID_SECRET, 3_600_000);
+
+        String token = jwtService.generateToken("user@test.com");
+
+        assertEquals("user@test.com", jwtService.extractLogin(token));
+    }
+
+    @Test
+    void shouldValidateTokenWhenSubjectMatchesAndTokenIsNotExpired() {
+        JwtService jwtService = new JwtService(VALID_SECRET, 3_600_000);
+        UserDetails userDetails = User.withUsername("user@test.com")
+                .password("ignored")
+                .authorities("ROLE_USER")
+                .build();
+
+        String token = jwtService.generateToken("user@test.com");
+
+        assertTrue(jwtService.isTokenValid(token, userDetails));
+    }
+
+    @Test
+    void shouldRejectTokenWhenSubjectDoesNotMatchUserDetails() {
+        JwtService jwtService = new JwtService(VALID_SECRET, 3_600_000);
+        UserDetails userDetails = User.withUsername("other@test.com")
+                .password("ignored")
+                .authorities("ROLE_USER")
+                .build();
+
+        String token = jwtService.generateToken("user@test.com");
+
+        assertFalse(jwtService.isTokenValid(token, userDetails));
+    }
+
+    @Test
+    void shouldThrowForExpiredTokenValidation() throws InterruptedException {
+        JwtService jwtService = new JwtService(VALID_SECRET, 1);
+        UserDetails userDetails = User.withUsername("user@test.com")
+                .password("ignored")
+                .authorities("ROLE_USER")
+                .build();
+
+        String token = jwtService.generateToken("user@test.com");
+        Thread.sleep(20);
+
+        assertThrows(ExpiredJwtException.class, () -> jwtService.isTokenValid(token, userDetails));
+    }
+
+    @Test
+    void shouldFailFastForInvalidBase64Secret() {
+        assertThrows(IllegalArgumentException.class, () -> new JwtService("not-base64", 3_600_000));
+    }
+
+    @Test
+    void shouldRejectTooShortDecodedSecret() {
+        String shortSecret = Base64.getEncoder().encodeToString("short-secret".getBytes());
+
+        assertThrows(WeakKeyException.class, () -> new JwtService(shortSecret, 3_600_000));
+    }
+
+    @Test
+    void shouldThrowForMalformedTokenExtraction() {
+        JwtService jwtService = new JwtService(VALID_SECRET, 3_600_000);
+
+        assertThrows(RuntimeException.class, () -> jwtService.extractLogin("definitely-not-a-jwt"));
+    }
+
+    private Claims parseClaims(String token, String secret) {
+        return Jwts.parser()
+                .verifyWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret)))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/test/java/com/example/telos/service/UserServiceImplTest.java
+++ b/src/test/java/com/example/telos/service/UserServiceImplTest.java
@@ -1,0 +1,152 @@
+package com.example.telos.service;
+
+import com.example.telos.dto.UserPasswordDto;
+import com.example.telos.dto.UserPasswordResponseDto;
+import com.example.telos.dto.UserUsernameResponseDto;
+import com.example.telos.exception.NullEntityReferenceException;
+import com.example.telos.exception.UsernameAlreadyTakenException;
+import com.example.telos.model.User;
+import com.example.telos.repository.UserRepository;
+import com.example.telos.service.impl.UserServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    void shouldTrimAndUpdateUsernameWhenValueIsAvailable() {
+        User currentUser = buildUser(1L, "user@test.com", "user", "encoded-password");
+
+        when(userRepository.findByUsername("new-name")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailOrUsername("user@test.com")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(currentUser));
+        when(userRepository.save(currentUser)).thenReturn(currentUser);
+
+        UserUsernameResponseDto response = userService.updateUsername("user@test.com", "  new-name  ");
+
+        assertEquals("new-name", currentUser.getUsername());
+        assertEquals("new-name", response.getUsername());
+        assertEquals("Username was successfully updated", response.getMessage());
+        verify(userRepository).save(currentUser);
+    }
+
+    @Test
+    void shouldRejectBlankUsername() {
+        NullEntityReferenceException exception = assertThrows(
+                NullEntityReferenceException.class,
+                () -> userService.updateUsername("user@test.com", "   ")
+        );
+
+        assertEquals("Username cannot be empty", exception.getMessage());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldRejectUsernameWhenTakenByAnotherUser() {
+        User currentUser = buildUser(1L, "user@test.com", "user", "encoded-password");
+        User anotherUser = buildUser(2L, "guest@test.com", "taken-name", "encoded-password");
+
+        when(userRepository.findByUsername("taken-name")).thenReturn(Optional.of(anotherUser));
+        when(userRepository.findByEmailOrUsername("user@test.com")).thenReturn(Optional.of(currentUser));
+
+        UsernameAlreadyTakenException exception = assertThrows(
+                UsernameAlreadyTakenException.class,
+                () -> userService.updateUsername("user@test.com", "taken-name")
+        );
+
+        assertEquals("Username is already taken", exception.getMessage());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void shouldEncodeAndUpdatePasswordWhenCurrentPasswordMatches() {
+        User currentUser = buildUser(1L, "user@test.com", "user", "encoded-old-password");
+        UserPasswordDto dto = new UserPasswordDto();
+        dto.setOldPassword("old-password");
+        dto.setNewPassword("new-password");
+        dto.setConfirmNewPassword("new-password");
+
+        when(userRepository.findByEmailOrUsername("user@test.com")).thenReturn(Optional.of(currentUser));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(currentUser));
+        when(passwordEncoder.matches("old-password", "encoded-old-password")).thenReturn(true);
+        when(passwordEncoder.encode("new-password")).thenReturn("encoded-new-password");
+        when(userRepository.save(currentUser)).thenReturn(currentUser);
+
+        UserPasswordResponseDto response = userService.updatePassword("user@test.com", dto);
+
+        assertEquals("encoded-new-password", currentUser.getPassword());
+        assertEquals("New password was successfully updated", response.getMessage());
+        verify(passwordEncoder).encode("new-password");
+        verify(userRepository).save(currentUser);
+    }
+
+    @Test
+    void shouldRejectPasswordUpdateWhenConfirmationDoesNotMatch() {
+        UserPasswordDto dto = new UserPasswordDto();
+        dto.setOldPassword("old-password");
+        dto.setNewPassword("new-password");
+        dto.setConfirmNewPassword("different-password");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.updatePassword("user@test.com", dto)
+        );
+
+        assertEquals("New password and confirm password don't match", exception.getMessage());
+        verify(userRepository, never()).findByEmailOrUsername(any());
+    }
+
+    @Test
+    void shouldRejectPasswordUpdateWhenCurrentPasswordIsIncorrect() {
+        User currentUser = buildUser(1L, "user@test.com", "user", "encoded-old-password");
+        UserPasswordDto dto = new UserPasswordDto();
+        dto.setOldPassword("wrong-old-password");
+        dto.setNewPassword("new-password");
+        dto.setConfirmNewPassword("new-password");
+
+        when(userRepository.findByEmailOrUsername("user@test.com")).thenReturn(Optional.of(currentUser));
+        when(passwordEncoder.matches("wrong-old-password", "encoded-old-password")).thenReturn(false);
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.updatePassword("user@test.com", dto)
+        );
+
+        assertEquals("Current password is incorrect", exception.getMessage());
+        verify(passwordEncoder, never()).encode(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    private User buildUser(Long id, String email, String username, String password) {
+        User user = new User();
+        ReflectionTestUtils.setField(user, "userId", id);
+        user.setEmail(email);
+        user.setUsername(username);
+        user.setPassword(password);
+        return user;
+    }
+}

--- a/src/test/java/com/example/telos/service/UserServiceImplTest.java
+++ b/src/test/java/com/example/telos/service/UserServiceImplTest.java
@@ -8,6 +8,8 @@ import com.example.telos.exception.UsernameAlreadyTakenException;
 import com.example.telos.model.User;
 import com.example.telos.repository.UserRepository;
 import com.example.telos.service.impl.UserServiceImpl;
+import com.example.telos.validation.Forbidden67Policy;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@Tag("contract")
 class UserServiceImplTest {
 
     @Mock
@@ -83,6 +86,19 @@ class UserServiceImplTest {
     }
 
     @Test
+    @Tag("negative")
+    void shouldRejectForbidden67Username() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.updateUsername("user@test.com", " six   seven ")
+        );
+
+        assertEquals(Forbidden67Policy.DEFAULT_MESSAGE, exception.getMessage());
+        verify(userRepository, never()).findByEmailOrUsername(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
     void shouldEncodeAndUpdatePasswordWhenCurrentPasswordMatches() {
         User currentUser = buildUser(1L, "user@test.com", "user", "encoded-old-password");
         UserPasswordDto dto = new UserPasswordDto();
@@ -117,6 +133,23 @@ class UserServiceImplTest {
         );
 
         assertEquals("New password and confirm password don't match", exception.getMessage());
+        verify(userRepository, never()).findByEmailOrUsername(any());
+    }
+
+    @Test
+    @Tag("negative")
+    void shouldRejectPasswordUpdateWhenNewPasswordIsTooShort() {
+        UserPasswordDto dto = new UserPasswordDto();
+        dto.setOldPassword("old-password");
+        dto.setNewPassword("short");
+        dto.setConfirmNewPassword("short");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> userService.updatePassword("user@test.com", dto)
+        );
+
+        assertEquals("New password must be at least 8 characters", exception.getMessage());
         verify(userRepository, never()).findByEmailOrUsername(any());
     }
 

--- a/src/test/java/com/example/telos/service/UserTimeSettingsServiceImplTest.java
+++ b/src/test/java/com/example/telos/service/UserTimeSettingsServiceImplTest.java
@@ -1,0 +1,132 @@
+package com.example.telos.service;
+
+import com.example.telos.dto.UserTimeSettingsDto;
+import com.example.telos.dto.UserTimeSettingsResponseDto;
+import com.example.telos.exception.NullEntityReferenceException;
+import com.example.telos.model.User;
+import com.example.telos.model.UserTimeSettings;
+import com.example.telos.repository.UserTimeSettingsRepository;
+import com.example.telos.service.impl.UserTimeSettingsServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserTimeSettingsServiceImplTest {
+
+    @Mock
+    private UserTimeSettingsRepository userTimeSettingsRepository;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UserTimeSettingsServiceImpl userTimeSettingsService;
+
+    @Test
+    void shouldReturnSettingsForExistingUser() {
+        User user = buildUser(1L, "user@test.com");
+        UserTimeSettings settings = buildSettings(10L, user, 25, 5, 15, 4, true);
+
+        when(userService.findByEmailOrUsername("user@test.com")).thenReturn(user);
+        when(userService.findById(1L)).thenReturn(user);
+        when(userTimeSettingsRepository.findByUser(user)).thenReturn(Optional.of(settings));
+
+        UserTimeSettingsResponseDto response = userTimeSettingsService.findSettings("user@test.com");
+
+        assertEquals(25, response.getPomodoroMinutes());
+        assertEquals(5, response.getShortBreakMinutes());
+        assertEquals(15, response.getLongBreakMinutes());
+        assertEquals(4, response.getPomoCycles());
+        assertEquals(true, response.isSoundsEnabled());
+        assertEquals("UserTimeSettings found", response.getMessage());
+    }
+
+    @Test
+    void shouldUpdateAndPersistAllSettingsFields() {
+        User user = buildUser(1L, "user@test.com");
+        UserTimeSettings settings = buildSettings(10L, user, 25, 5, 15, 4, true);
+        UserTimeSettingsDto dto = new UserTimeSettingsDto();
+        dto.setPomodoroMinutes(35);
+        dto.setShortBreakMinutes(10);
+        dto.setLongBreakMinutes(20);
+        dto.setPomoCycles(2);
+        dto.setSoundsEnabled(false);
+
+        when(userService.findByEmailOrUsername("user@test.com")).thenReturn(user);
+        when(userService.findById(1L)).thenReturn(user);
+        when(userTimeSettingsRepository.findByUser(user)).thenReturn(Optional.of(settings));
+        when(userTimeSettingsRepository.save(settings)).thenReturn(settings);
+
+        UserTimeSettingsResponseDto response = userTimeSettingsService.updateSettings("user@test.com", dto);
+
+        assertEquals(35, settings.getPomodoroMinutes());
+        assertEquals(10, settings.getShortBreakMinutes());
+        assertEquals(20, settings.getLongBreakMinutes());
+        assertEquals(2, settings.getPomoCycles());
+        assertFalse(settings.getSoundsEnable());
+        assertEquals("UserTimeSettings updated", response.getMessage());
+        verify(userTimeSettingsRepository).save(settings);
+    }
+
+    @Test
+    void shouldRejectFindByUserWhenUserIsNull() {
+        NullEntityReferenceException exception = assertThrows(
+                NullEntityReferenceException.class,
+                () -> userTimeSettingsService.findByUser(null)
+        );
+
+        assertEquals("User is null", exception.getMessage());
+    }
+
+    @Test
+    void shouldRejectUpdateSettingsWhenUserHasNoId() {
+        User user = buildUser(null, "user@test.com");
+        UserTimeSettingsDto dto = new UserTimeSettingsDto();
+        dto.setPomodoroMinutes(25);
+        dto.setShortBreakMinutes(5);
+        dto.setLongBreakMinutes(15);
+        dto.setPomoCycles(4);
+        dto.setSoundsEnabled(true);
+
+        when(userService.findByEmailOrUsername("user@test.com")).thenReturn(user);
+
+        NullEntityReferenceException exception = assertThrows(
+                NullEntityReferenceException.class,
+                () -> userTimeSettingsService.updateSettings("user@test.com", dto)
+        );
+
+        assertEquals("User id is null", exception.getMessage());
+    }
+
+    private User buildUser(Long id, String email) {
+        User user = new User();
+        ReflectionTestUtils.setField(user, "userId", id);
+        user.setEmail(email);
+        user.setUsername("demo-user");
+        return user;
+    }
+
+    private UserTimeSettings buildSettings(Long id, User user, int pomodoro, int shortBreak, int longBreak, int cycles, boolean soundsEnabled) {
+        UserTimeSettings settings = new UserTimeSettings();
+        ReflectionTestUtils.setField(settings, "settingsId", id);
+        ReflectionTestUtils.setField(settings, "user", user);
+        settings.setPomodoroMinutes(pomodoro);
+        settings.setShortBreakMinutes(shortBreak);
+        settings.setLongBreakMinutes(longBreak);
+        settings.setPomoCycles(cycles);
+        settings.setSoundsEnable(soundsEnabled);
+        return settings;
+    }
+}

--- a/src/test/java/com/example/telos/validation/Forbidden67PolicyTest.java
+++ b/src/test/java/com/example/telos/validation/Forbidden67PolicyTest.java
@@ -1,0 +1,31 @@
+package com.example.telos.validation;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("negative")
+class Forbidden67PolicyTest {
+
+    @Test
+    void shouldRejectExactNumeric67Token() {
+        assertTrue(Forbidden67Policy.containsForbiddenToken("67"));
+        assertTrue(Forbidden67Policy.containsForbiddenToken(" 67 "));
+    }
+
+    @Test
+    void shouldRejectExactSixSevenTokenCaseInsensitively() {
+        assertTrue(Forbidden67Policy.containsForbiddenToken("six seven"));
+        assertTrue(Forbidden67Policy.containsForbiddenToken(" Six   Seven "));
+    }
+
+    @Test
+    void shouldAllowOtherValues() {
+        assertFalse(Forbidden67Policy.containsForbiddenToken("demo-user"));
+        assertFalse(Forbidden67Policy.containsForbiddenToken("167"));
+        assertFalse(Forbidden67Policy.containsForbiddenToken("sixty seven"));
+        assertFalse(Forbidden67Policy.containsForbiddenToken(null));
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/tests/AutomationExecutionPlan.md
+++ b/tests/AutomationExecutionPlan.md
@@ -1,0 +1,328 @@
+# Automation Execution Plan
+
+This document turns the current testing strategy into a concrete implementation backlog.
+
+Use it as the working plan for adding automated coverage in the repository.
+
+## Goals
+
+- close the current gap between documented coverage and executable coverage
+- prioritize cheaper and more stable checks before expensive browser flows
+- keep each phase small enough to review and merge safely
+- introduce `anti-67` testing as a cross-cutting validation rule without hiding where product logic must be added first
+
+## Delivery Rules
+
+- Prefer lower layers first:
+  - `WebMvc` before `Playwright` when a contract can be validated without a browser
+  - Java unit before integration when logic is isolated enough
+- Add executable tests in the same phase as the underlying implementation, not before it exists.
+- For `anti-67`, do not leave browser-only validation as the single enforcement layer.
+- Keep smoke suites environment-safe and reusable on `https://teclos.space` or another remote target.
+
+## Phase 0. Infrastructure And Readiness
+
+### Outcome
+
+Stabilize the test environment so the later suites can be added without ad hoc setup.
+
+### Tasks
+
+- Add JaCoCo to Maven so backend coverage is measurable.
+- Introduce a committed Playwright project config if the team wants browser automation to scale beyond ad hoc commands.
+- Define naming/tagging conventions:
+  - `smoke`
+  - `regression`
+  - `api`
+  - `auth`
+  - `ui`
+  - `anti-67`
+- Document reusable environment variables:
+  - `E2E_BASE_URL`
+  - `E2E_DEV_BASE_URL`
+  - `E2E_LOGIN_USERNAME`
+  - `E2E_LOGIN_PASSWORD`
+- Decide how mutable test data is reset for username/password mutation flows.
+
+### Deliverables
+
+- `pom.xml` updated with JaCoCo
+- Playwright config committed to the repo
+- short contributor note in `tests/` or `README.md` describing how to run the main suites
+
+## Phase 1. WebMvc And Integration For Session APIs
+
+### Outcome
+
+Lock down the main session-based contracts under `/api/user/**`.
+
+### Test Files To Add
+
+- `src/test/java/com/example/telos/api/UserTimeSettingsControllerTest.java`
+- `src/test/java/com/example/telos/api/UserProfileControllerTest.java`
+- `src/test/java/com/example/telos/integration/UserTimeSettingsIntegrationTest.java`
+- `src/test/java/com/example/telos/integration/UserProfileIntegrationTest.java`
+
+### Coverage
+
+- `GET /api/user/time-settings`
+  - anonymous -> unauthorized
+  - authenticated -> `200`
+  - response JSON shape
+- `PATCH /api/user/time-settings`
+  - authenticated valid payload
+  - invalid bounds
+  - malformed JSON
+  - missing CSRF
+  - unauthorized access
+- `PATCH /api/user/username`
+  - happy path
+  - blank username
+  - conflict path
+  - missing CSRF
+  - unauthorized access
+- `PATCH /api/user/password`
+  - happy path
+  - wrong current password
+  - mismatched confirmation
+  - missing required fields
+  - missing CSRF
+  - unauthorized access
+
+### Anti-67 Coverage In This Phase
+
+- If username validation is extended with the easter egg:
+  - reject `67`
+  - reject `six seven`
+  - reject case-insensitive variants
+- If time-settings inputs should reject literal `67` in any field, encode that rule here too.
+- API responses must be stable and explicit when an `anti-67` validation rule fires.
+
+### Dependencies
+
+- `spring-security-test`
+- stable error response contract
+- seeded authenticated test user or mocked auth principal
+
+## Phase 2. WebMvc And Integration For JWT APIs
+
+### Outcome
+
+Lock down the JWT-facing contracts under `/api/jwt/**`.
+
+### Test Files To Add
+
+- `src/test/java/com/example/telos/api/AuthJwtControllerTest.java`
+- `src/test/java/com/example/telos/api/UserJwtControllerTest.java`
+- `src/test/java/com/example/telos/integration/JwtAuthIntegrationTest.java`
+
+### Coverage
+
+- `POST /api/jwt/auth/login`
+  - valid credentials
+  - invalid credentials
+  - response token shape
+- `PATCH /api/jwt/user/username`
+  - valid JWT auth
+  - invalid JWT
+  - blank/conflict validation
+- `PATCH /api/jwt/user/password`
+  - valid JWT auth
+  - mismatched confirmation
+  - wrong current password
+- JWT time-settings endpoints if present
+
+### Anti-67 Coverage In This Phase
+
+- Mirror the same rejection rules for `anti-67` on JWT username/password-related inputs if those fields are in scope.
+- Session and JWT APIs must not diverge on `anti-67` behavior.
+
+## Phase 3. Java Unit Tests
+
+### Outcome
+
+Cover pure Java logic cheaply before growing the integration matrix further.
+
+### Test Files To Add
+
+- `src/test/java/com/example/telos/service/UserServiceImplTest.java`
+- `src/test/java/com/example/telos/service/UserTimeSettingsServiceImplTest.java`
+- `src/test/java/com/example/telos/security/JwtServiceTest.java`
+- `src/test/java/com/example/telos/security/JwtFilterTest.java`
+- `src/test/java/com/example/telos/service/LogErrorServiceImplTest.java`
+
+### Coverage
+
+- `UserServiceImpl`
+  - find/load behavior
+  - username update rules
+  - password update rules
+  - encoding behavior
+  - conflict handling
+- `UserTimeSettingsServiceImpl`
+  - load settings for current user
+  - update all fields
+  - persistence-facing rules without MVC
+- `JwtService`
+  - token generation
+  - parsing
+  - expiry validation
+  - subject extraction
+- `JwtFilter`
+  - skip when no header exists
+  - authenticate when token is valid
+  - ignore invalid token safely
+- `LogErrorServiceImpl`
+  - save only expected error cases
+
+### Anti-67 Coverage In This Phase
+
+- If `anti-67` is implemented through a dedicated validator/helper, add direct unit coverage here.
+- Preferred implementation shape:
+  - one shared backend validation helper
+  - one small suite verifying:
+    - exact `67`
+    - exact `six seven`
+    - uppercase/lowercase variants
+    - trimmed variants
+    - safe non-matching values
+
+## Phase 4. Playwright Core Browser Flows
+
+### Outcome
+
+Cover the main user-visible flows that cannot be trusted without a real browser.
+
+### Test Files To Add
+
+- `tests/e2e/home-timer.spec.js`
+- `tests/e2e/home-settings.spec.js`
+- `tests/e2e/user-profile.spec.js`
+- `tests/e2e/productivity.spec.js`
+
+### Coverage
+
+- Home timer
+  - page shell
+  - start
+  - pause
+  - reset
+  - mode visibility
+  - reload recovery
+- Home settings
+  - open/close
+  - validation
+  - save/cancel
+  - authenticated sync if test creds exist
+- User profile
+  - page render
+  - username form
+  - password form
+  - visible feedback
+- Productivity
+  - tab switching
+  - todo add/edit/delete
+  - notes add/edit/delete
+  - storage persistence
+
+### Anti-67 Coverage In This Phase
+
+- Browser-visible validation must be checked anywhere the user can type text:
+  - login identifier
+  - username field
+  - productivity task input
+  - productivity note input
+- Browser expectations:
+  - invalid value is visibly rejected
+  - form submit is blocked where client validation exists
+  - error state clears after valid input
+
+## Phase 5. Cross-Page And Shared UI Browser Coverage
+
+### Outcome
+
+Cover shared behavior that currently exists only in documentation or manual checks.
+
+### Test Files To Add
+
+- `tests/e2e/mini-timer-sync.spec.js`
+- `tests/e2e/header-footer.spec.js`
+- `tests/e2e/error-pages.spec.js`
+- `tests/e2e/static-pages.spec.js`
+
+### Coverage
+
+- mini timer visibility on non-home pages
+- mini timer state reflection after timer changes
+- header nav visibility and route links
+- footer presence across target pages
+- 403 and 404 recovery navigation
+- about/helpus smoke
+
+### Anti-67 Coverage In This Phase
+
+- none by default unless a shared input surface is added later
+
+## Phase 6. Anti-67 Feature Matrix
+
+This is the easter egg validation matrix that should be applied only where it makes sense for user-entered values.
+
+### Candidate Inputs
+
+- login identifier
+- profile username
+- productivity todo text
+- productivity note content
+- any future free-text field
+
+### Default Rule Proposal
+
+- reject exact `67`
+- reject text containing `67` as a distinct token
+- reject `six seven` case-insensitively
+- accept unrelated values such as:
+  - `667`
+  - `sixty seven`
+  - `alpha`
+
+### Questions To Lock Before Full Implementation
+
+- Should `abc67xyz` be rejected or allowed?
+- Should `67` inside passwords be rejected or should passwords stay out of scope for the joke rule?
+- Should numeric timer settings reject `67`, or is the easter egg text-only?
+
+### Recommended Implementation Shape
+
+- frontend:
+  - small reusable validator/helper for text inputs
+- backend:
+  - one reusable validation rule or helper
+- tests:
+  - unit
+  - `WebMvc`
+  - Playwright only where user-visible feedback matters
+
+## Concrete Backlog Order
+
+1. Add JaCoCo and Playwright config.
+2. Add `WebMvc` session API tests for `/api/user/time-settings`.
+3. Add `WebMvc` session API tests for `/api/user/username` and `/api/user/password`.
+4. Add `WebMvc` JWT auth and user API tests.
+5. Add Java unit tests for `UserServiceImpl` and `UserTimeSettingsServiceImpl`.
+6. Add Java unit tests for `JwtService` and `JwtFilter`.
+7. Add Playwright home timer and settings flows.
+8. Add Playwright user profile flows.
+9. Add Playwright productivity flows.
+10. Add shared UI and error/static smoke suites.
+11. Lock `anti-67` scope in product behavior.
+12. Add backend `anti-67` tests.
+13. Add frontend and browser `anti-67` tests.
+
+## Done Criteria
+
+The plan is considered implemented when:
+
+- each phase has executable tests in the repo
+- the planned files exist or their scope is covered by equivalent test files
+- `anti-67` behavior is either implemented with tests or explicitly marked out of scope in the docs
+- remote smoke and local automation can both be run using documented commands

--- a/tests/AutomationRoadmap.md
+++ b/tests/AutomationRoadmap.md
@@ -91,6 +91,10 @@ Recommendation:
 - decide whether browser automation will live in Playwright or another runner and commit the config to the repo
 - document DB reset strategy for mutable tests
 - keep using the split docs as the source of truth for test cases
+- implement the new technical planning folders first:
+  - `tests/unit-java`
+  - `tests/unit-js`
+  - `tests/e2e`
 
 ### Phase 1: P0 Backend Safety Net
 
@@ -108,6 +112,7 @@ Source docs to start from:
 - `tests/login`
 - `tests/user`
 - `tests/index/08-authenticated-settings-sync.md`
+- `tests/unit-java`
 
 ### Phase 2: P0 Browser Journeys
 
@@ -125,6 +130,7 @@ Source docs to start from:
 - `tests/index`
 - `tests/productivity`
 - `tests/user`
+- `tests/e2e`
 
 ### Phase 3: Shared UI And Error Surfaces
 
@@ -157,6 +163,17 @@ Source docs to start from:
 - `tests/about`
 - `tests/helpus`
 - `tests/error-generic`
+
+### Phase 5: Narrow JS Stabilization
+
+Automate only after the main browser and backend safety nets exist:
+
+- `timer-state.js` normalization and transition helpers
+- productivity storage normalization helpers if they are extracted
+
+Source docs to start from:
+
+- `tests/unit-js`
 
 ## Selector And Hook Strategy
 

--- a/tests/AutomationRoadmap.md
+++ b/tests/AutomationRoadmap.md
@@ -2,6 +2,8 @@
 
 This document translates the written scenario coverage under `tests/` into an implementation order for future automation.
 
+For the concrete file-by-file execution backlog, see [AutomationExecutionPlan.md](AutomationExecutionPlan.md).
+
 ## Goals
 
 - convert the most critical documented scenarios into stable automated checks

--- a/tests/NegativeTestLanes.md
+++ b/tests/NegativeTestLanes.md
@@ -1,0 +1,67 @@
+# Negative Test Lanes
+
+## Purpose
+
+This document explains how to run the negative-test automation without mixing gap-finding checks into the normal green path.
+
+## Lanes
+
+- `blocking`: negative and contract checks for behavior that already exists and should stay stable
+- `known-gap`: desired behavior that may still fail until implementation catches up
+- `ui-negative`: browser-visible validation and error-state checks
+
+## Java Tags
+
+- `negative`
+- `contract`
+- `known-gap`
+
+## JS Naming
+
+Node test titles use inline labels like:
+
+- `[ui-negative]`
+- `[known-gap]`
+
+This keeps the files runnable with plain `node --test`, while still making their intent visible in output and CI logs.
+
+## Playwright Naming
+
+Playwright test titles use inline tags:
+
+- `@ui-negative`
+- `@known-gap`
+
+The current negative browser specs live in [negative-browser-flows.spec.js](e2e/negative-browser-flows.spec.js).
+
+## Recommended Commands
+
+Blocking Java negative layer:
+
+```bash
+./mvnw -q -Dtest='Forbidden67PolicyTest,UserServiceImplTest,UserTimeSettingsRestControllerTest,UserRestControllerTest,AuthJwtControllerTest,UserJwtControllerTest' test
+```
+
+Known-gap Java lane:
+
+```bash
+./mvnw -q -DrunKnownGaps=true -Dtest='UserTimeSettingsRestControllerTest' test
+```
+
+Blocking JS negative layer:
+
+```bash
+node --test tests/unit-js/settings-validation.test.mjs tests/unit-js/login-validation.test.mjs tests/unit-js/user-profile-validation.test.mjs tests/unit-js/productivity-interactions.test.mjs
+```
+
+Browser negative layer:
+
+```bash
+npx playwright test tests/e2e/negative-browser-flows.spec.js --reporter=line
+```
+
+## Current Known Gaps
+
+- form-login redirect-back behavior is still documented as a desired gap, but not kept as a runnable Java suite because the dedicated MockMvc form-login slice currently fails during security filter initialization on the current stack
+- session timer settings still accept decimal JSON values through coercion; a strict-integer known-gap test exists behind `runKnownGaps=true`
+- remote [teclos.space](https://teclos.space) may lag behind local branch assets, so some browser-negative specs intentionally skip there

--- a/tests/TestPlan01.md
+++ b/tests/TestPlan01.md
@@ -5,6 +5,7 @@ This file is the entrypoint for the split test-plan structure under `tests/`.
 The original monolithic page plan has been decomposed into page-level and shared-UI folders so each functional slice can later map cleanly to manual checks, automated specs, or implementation tasks.
 
 For the implementation order and automation strategy, see [AutomationRoadmap.md](AutomationRoadmap.md).
+For the concrete execution backlog, see [AutomationExecutionPlan.md](AutomationExecutionPlan.md).
 
 ## How To Use This Structure
 

--- a/tests/TestPlan01.md
+++ b/tests/TestPlan01.md
@@ -121,6 +121,11 @@ For the implementation order and automation strategy, see [AutomationRoadmap.md]
   - [08-cross-tab-sync-and-mini-timer](e2e/08-cross-tab-sync-and-mini-timer.md)
   - [09-static-and-error-pages-smoke](e2e/09-static-and-error-pages-smoke.md)
 
+### Manual Checklists
+
+- [Manual checklists index](manual/README.md)
+  - [01-core-flows-regression-checklist](manual/01-core-flows-regression-checklist.md)
+
 ## Folder Conventions
 
 - Every folder contains a `README.md` with the source surface and file index.

--- a/tests/TestPlan01.md
+++ b/tests/TestPlan01.md
@@ -98,6 +98,29 @@ For the implementation order and automation strategy, see [AutomationRoadmap.md]
   - [02-mini-timer-runtime-contract](mini-timer-scripts/02-mini-timer-runtime-contract.md)
   - [03-settings-sync-side-effects](mini-timer-scripts/03-settings-sync-side-effects.md)
 
+### Technical Layers
+
+- [Java unit plans](unit-java/README.md)
+  - [01-user-service](unit-java/01-user-service.md)
+  - [02-user-time-settings-service](unit-java/02-user-time-settings-service.md)
+  - [03-log-error-service](unit-java/03-log-error-service.md)
+  - [04-jwt-service](unit-java/04-jwt-service.md)
+  - [05-jwt-filter](unit-java/05-jwt-filter.md)
+- [JavaScript unit plans](unit-js/README.md)
+  - [01-timer-state-normalization-and-storage](unit-js/01-timer-state-normalization-and-storage.md)
+  - [02-timer-state-transitions-and-projections](unit-js/02-timer-state-transitions-and-projections.md)
+  - [03-productivity-storage-and-sanitization](unit-js/03-productivity-storage-and-sanitization.md)
+- [E2E plans](e2e/README.md)
+  - [01-auth-and-route-guards](e2e/01-auth-and-route-guards.md)
+  - [02-home-timer-core-flow](e2e/02-home-timer-core-flow.md)
+  - [03-home-settings-anonymous](e2e/03-home-settings-anonymous.md)
+  - [04-home-settings-authenticated](e2e/04-home-settings-authenticated.md)
+  - [05-user-profile-management](e2e/05-user-profile-management.md)
+  - [06-productivity-todo-flow](e2e/06-productivity-todo-flow.md)
+  - [07-productivity-notes-and-keyboard-flow](e2e/07-productivity-notes-and-keyboard-flow.md)
+  - [08-cross-tab-sync-and-mini-timer](e2e/08-cross-tab-sync-and-mini-timer.md)
+  - [09-static-and-error-pages-smoke](e2e/09-static-and-error-pages-smoke.md)
+
 ## Folder Conventions
 
 - Every folder contains a `README.md` with the source surface and file index.

--- a/tests/TestPlan01.md
+++ b/tests/TestPlan01.md
@@ -6,6 +6,7 @@ The original monolithic page plan has been decomposed into page-level and shared
 
 For the implementation order and automation strategy, see [AutomationRoadmap.md](AutomationRoadmap.md).
 For the concrete execution backlog, see [AutomationExecutionPlan.md](AutomationExecutionPlan.md).
+For blocking vs known-gap negative execution, see [NegativeTestLanes.md](NegativeTestLanes.md).
 
 ## How To Use This Structure
 

--- a/tests/e2e/01-auth-and-route-guards.md
+++ b/tests/e2e/01-auth-and-route-guards.md
@@ -1,0 +1,49 @@
+# E2E Auth And Route Guards
+
+## Purpose
+
+Define browser journeys for authentication entry, route protection, and basic session transitions.
+
+## Source Surface
+
+- Pages:
+  - `/login`
+  - `/user`
+- Session auth flow:
+  - `POST /login`
+  - `POST /logout`
+
+## User Story / Functional Slice
+
+As a user, I can log in, reach protected pages, and log out; as an anonymous user, I cannot access protected content directly.
+
+## Dependencies
+
+- seeded or dedicated test user
+- stable hooks:
+  - `#loginIdentifier`
+  - `#loginPassword`
+  - `#loginForm`
+
+## Happy Path Scenarios
+
+- anonymous user opens `/login`
+- valid email login redirects to `/user`
+- valid username login redirects to `/user`
+- authenticated user opens `/user` successfully
+- logout returns the user to `/`
+
+## Negative / Edge Scenarios
+
+- anonymous direct navigation to `/user` does not reveal protected content
+- invalid credentials stay in login flow and show visible error message
+- logged-out user loses access to `/user`
+
+## Accessibility / UI States
+
+- login form is keyboard-usable end-to-end
+- auth error state remains visible after failed login
+
+## Data / Auth / Storage Notes
+
+- Prefer a dedicated mutable account so later profile tests can reuse the same session safely

--- a/tests/e2e/02-home-timer-core-flow.md
+++ b/tests/e2e/02-home-timer-core-flow.md
@@ -1,0 +1,46 @@
+# E2E Home Timer Core Flow
+
+## Purpose
+
+Define the main browser journey for the timer on the home page.
+
+## Source Surface
+
+- Page: `/`
+- Scripts:
+  - `timer.js`
+  - `timer-state.js`
+
+## User Story / Functional Slice
+
+As a user, I can start, pause, resume, and reset the timer while the page reflects the correct mode and remaining time.
+
+## Dependencies
+
+- stable hooks:
+  - `#startBtn`
+  - `#resetBtn`
+  - `#timeDisplay`
+
+## Happy Path Scenarios
+
+- page loads with default `25:00`
+- clicking Start begins countdown
+- clicking Pause freezes countdown
+- clicking Start again resumes countdown
+- clicking Reset returns to default pomodoro state
+
+## Negative / Edge Scenarios
+
+- rapid Start/Pause interaction does not produce duplicated countdown behavior
+- reset during running state stops countdown cleanly
+
+## Accessibility / UI States
+
+- button text changes are visible and keyboard reachable
+- timer text remains readable while running
+
+## Data / Auth / Storage Notes
+
+- clear `pomodoroTimerState` before each run
+- this journey should avoid relying on audio playback assertions first

--- a/tests/e2e/03-home-settings-anonymous.md
+++ b/tests/e2e/03-home-settings-anonymous.md
@@ -1,0 +1,47 @@
+# E2E Home Settings Anonymous Flow
+
+## Purpose
+
+Define the browser journey for local-only settings behavior when the user is not authenticated.
+
+## Source Surface
+
+- Page: `/`
+- Script: `settings.js`
+
+## User Story / Functional Slice
+
+As an anonymous user, I can adjust timer settings locally without needing server persistence.
+
+## Dependencies
+
+- stable hooks:
+  - `#settingsToggle`
+  - `#pomodoroTime`
+  - `#shortBreakTime`
+  - `#longBreakTime`
+  - `#focusCycles`
+  - `#soundEnabled`
+  - `#saveSettings`
+  - `#cancelSettings`
+
+## Happy Path Scenarios
+
+- anonymous user opens settings
+- valid settings save closes the panel
+- refreshed page retains saved settings via local storage
+- cancel discards unsaved field edits
+
+## Negative / Edge Scenarios
+
+- invalid numeric values are rejected visibly
+- anonymous save must not depend on server availability
+
+## Accessibility / UI States
+
+- settings fields are keyboard reachable
+- invalid state is visible and recoverable
+
+## Data / Auth / Storage Notes
+
+- assertions should include local storage updates to `pomodoroSettings`

--- a/tests/e2e/04-home-settings-authenticated.md
+++ b/tests/e2e/04-home-settings-authenticated.md
@@ -1,0 +1,39 @@
+# E2E Home Settings Authenticated Flow
+
+## Purpose
+
+Define the browser journey for authenticated timer settings sync.
+
+## Source Surface
+
+- Pages: `/login`, `/`
+- Session API: `/api/user/time-settings`
+
+## User Story / Functional Slice
+
+As an authenticated user, I can load server-backed timer settings and update them through the UI.
+
+## Dependencies
+
+- authenticated browser session
+- same stable hooks as anonymous settings flow
+
+## Happy Path Scenarios
+
+- authenticated user lands on home page with server-backed settings applied
+- changing and saving settings persists through page reload
+- settings update affects visible timer-related text and counts
+
+## Negative / Edge Scenarios
+
+- running timer keeps settings toggle disabled
+- failed save should show visible error and preserve previous good values
+
+## Accessibility / UI States
+
+- sync-related messages remain visible in the shared settings message area
+
+## Data / Auth / Storage Notes
+
+- assertions should include visible UI change, not just network success
+- use dedicated mutable account or reset strategy after run

--- a/tests/e2e/05-user-profile-management.md
+++ b/tests/e2e/05-user-profile-management.md
@@ -1,0 +1,48 @@
+# E2E User Profile Management
+
+## Purpose
+
+Define end-to-end journeys for username and password management on the user page.
+
+## Source Surface
+
+- Page: `/user`
+- Script: `user-settings.js`
+
+## User Story / Functional Slice
+
+As an authenticated user, I can update my username and password and receive visible feedback directly in the UI.
+
+## Dependencies
+
+- authenticated session
+- stable hooks:
+  - `#username`
+  - `#username-form`
+  - `#username-message`
+  - `#oldPassword`
+  - `#newPassword`
+  - `#confirmNewPassword`
+  - `#password-form`
+  - `#password-message`
+
+## Happy Path Scenarios
+
+- username update success shows success message and updated field value
+- password update success shows success message and clears password fields
+
+## Negative / Edge Scenarios
+
+- duplicate username shows server validation message
+- empty username is rejected
+- wrong current password shows error message
+- mismatched new passwords show error message
+
+## Accessibility / UI States
+
+- both forms remain independently usable after an error in one of them
+- feedback messages are visible and localized to the relevant form
+
+## Data / Auth / Storage Notes
+
+- this suite should use a dedicated mutable account to avoid polluting seeded users

--- a/tests/e2e/06-productivity-todo-flow.md
+++ b/tests/e2e/06-productivity-todo-flow.md
@@ -1,0 +1,46 @@
+# E2E Productivity Todo Flow
+
+## Purpose
+
+Define end-to-end journeys for the todo portion of the productivity page.
+
+## Source Surface
+
+- Page: `/productivity`
+- Script: `productivity.js`
+
+## User Story / Functional Slice
+
+As a user, I can create, edit, complete, and delete todo items in the browser.
+
+## Dependencies
+
+- stable hooks:
+  - `#todoInput`
+  - `data-entry-form="todo"`
+  - `data-item-list="todo"`
+  - `data-empty-state="todo"`
+
+## Happy Path Scenarios
+
+- todo tab is active on page load
+- user adds a task
+- task appears in list and empty state disappears
+- user edits task text and saves
+- user toggles task completion
+- user deletes task and list returns to empty state when appropriate
+
+## Negative / Edge Scenarios
+
+- blank task submission shows validation feedback
+- HTML payload is rendered escaped, not executed
+
+## Accessibility / UI States
+
+- keyboard can reach add/edit/delete controls
+- completed visual state remains distinguishable
+
+## Data / Auth / Storage Notes
+
+- clear `telos.productivity.v1` before run
+- verify persistence across reload where useful

--- a/tests/e2e/07-productivity-notes-and-keyboard-flow.md
+++ b/tests/e2e/07-productivity-notes-and-keyboard-flow.md
@@ -1,0 +1,45 @@
+# E2E Productivity Notes And Keyboard Flow
+
+## Purpose
+
+Define end-to-end journeys for notes, including keyboard-driven editing.
+
+## Source Surface
+
+- Page: `/productivity`
+- Script: `productivity.js`
+
+## User Story / Functional Slice
+
+As a user, I can manage notes and use the intended keyboard shortcuts while editing.
+
+## Dependencies
+
+- stable hooks:
+  - `#noteInput`
+  - `data-entry-form="notes"`
+  - `data-item-list="notes"`
+  - `data-empty-state="notes"`
+
+## Happy Path Scenarios
+
+- user switches to Notes tab
+- user adds a note
+- note renders with visible content
+- user edits the note and saves with `Ctrl+Enter` or `Cmd+Enter`
+- user deletes the note
+
+## Negative / Edge Scenarios
+
+- blank note submission shows validation feedback
+- raw HTML/script payload is escaped in rendered note content
+- note editing should not save on plain `Enter` without modifier
+
+## Accessibility / UI States
+
+- tab switch and note controls are keyboard reachable
+- textarea editing remains usable for multi-line content
+
+## Data / Auth / Storage Notes
+
+- clear `telos.productivity.v1` before run

--- a/tests/e2e/08-cross-tab-sync-and-mini-timer.md
+++ b/tests/e2e/08-cross-tab-sync-and-mini-timer.md
@@ -1,0 +1,52 @@
+# E2E Cross Tab Sync And Mini Timer
+
+## Purpose
+
+Define browser journeys that require two tabs or windows and shared timer/productivity state propagation.
+
+## Source Surface
+
+- Pages:
+  - `/`
+  - `/productivity`
+  - `/user`
+  - `/about`
+- Shared scripts:
+  - `timer-state.js`
+  - `mini-timer.js`
+  - `mini-timer-sync.js`
+
+## User Story / Functional Slice
+
+As a user with multiple tabs open, I can see timer and productivity changes propagate across those tabs.
+
+## Dependencies
+
+- multi-page browser context
+- stable hooks:
+  - `#miniTimer`
+  - `#miniTimerTime`
+  - `#miniTimerStatus`
+  - `#timeDisplay`
+
+## Happy Path Scenarios
+
+- timer started on home page updates mini-timer on a non-home page
+- settings saved on home page update mini-timer-dependent state on a non-home page
+- productivity changes in one tab appear in another productivity tab via storage event
+
+## Negative / Edge Scenarios
+
+- cross-tab updates should not duplicate list entries
+- static pages without full timer UI should still show coherent mini-timer state if scripts support it
+- pages with partial script inclusion, such as 404, should be tested as explicit exceptions if included in browser coverage
+
+## Accessibility / UI States
+
+- updated mini-timer text remains readable after sync
+- cross-tab changes should not leave controls visually inconsistent
+
+## Data / Auth / Storage Notes
+
+- this suite is inherently more fragile; schedule it after P0 single-tab flows
+- isolate storage state carefully before launching second tab

--- a/tests/e2e/09-static-and-error-pages-smoke.md
+++ b/tests/e2e/09-static-and-error-pages-smoke.md
@@ -1,0 +1,43 @@
+# E2E Static And Error Pages Smoke
+
+## Purpose
+
+Define lightweight browser smoke checks for static public pages and custom error pages.
+
+## Source Surface
+
+- Pages:
+  - `/about`
+  - `/helpus`
+  - 403 rendering path
+  - 404 rendering path
+
+## User Story / Functional Slice
+
+As a user, I can reach static content pages and get navigable custom error pages when something goes wrong.
+
+## Dependencies
+
+- browser navigation
+- recovery links on error pages
+
+## Happy Path Scenarios
+
+- about page loads and shows expected heading/copy
+- helpus page loads and shows support links and donation image
+- custom 404 page renders and recovers to home page
+- custom 403 page renders and recovers to home page
+
+## Negative / Edge Scenarios
+
+- broken external links on helpus page are regressions
+- error pages must not show blank screens or raw exceptions
+
+## Accessibility / UI States
+
+- headings and recovery links remain keyboard reachable
+- static content remains visible without user interaction
+
+## Data / Auth / Storage Notes
+
+- keep this suite smoke-only; do not spend deep browser-runtime coverage budget here first

--- a/tests/e2e/10-dev-deployment-smoke-results.md
+++ b/tests/e2e/10-dev-deployment-smoke-results.md
@@ -1,0 +1,42 @@
+# Dev Deployment Smoke Results
+
+## Purpose
+
+Record remote smoke runs for the deployed dev environment.
+
+## Executed Suite
+
+- [dev-deployment-smoke.spec.js](dev-deployment-smoke.spec.js)
+
+## Target Pages
+
+- `/`
+- `/productivity`
+- `/login`
+
+## Coverage
+
+- deployment is reachable by URL
+- key UI elements render on the target pages
+- no obvious horizontal layout break is detected
+- no critical `console.error` or uncaught `pageerror` is emitted during base navigation
+
+## Result
+
+- Execution date: `2026-04-08`
+- Result status: passed
+- Target URL:
+  - `E2E_DEV_BASE_URL` or `E2E_BASE_URL`
+  - default fallback: `https://teclos.space`
+- Command:
+  - `npx playwright test tests/e2e/dev-deployment-smoke.spec.js --reporter=line`
+- Outcome:
+  - `3 passed`
+- Passed pages:
+  - `/`
+  - `/productivity`
+  - `/login`
+- Notes:
+  - smoke checks use `domcontentloaded` plus visible UI hooks, which is a better fit for deployed pages with ongoing browser activity than `networkidle`
+  - anonymous `401` noise from timer-settings sync on public pages is treated as expected non-critical behavior and is filtered from the console-error assertion
+  - the deployed `/productivity` page currently renders an anonymous `Login required` guest-card variant rather than the tabbed workspace; the smoke suite accepts either variant as valid primary UI for that route

--- a/tests/e2e/10-dev-deployment-smoke.md
+++ b/tests/e2e/10-dev-deployment-smoke.md
@@ -1,0 +1,50 @@
+# E2E Dev Deployment Smoke
+
+## Purpose
+
+Define a lightweight post-deploy smoke suite for the remote dev environment.
+
+## Source Surface
+
+- Pages:
+  - `/`
+  - `/productivity`
+  - `/login`
+
+## User Story / Functional Slice
+
+As a team, we can verify that the deployed dev environment is reachable and that the core public pages render without critical browser/runtime failures.
+
+## Dependencies
+
+- remote base URL:
+  - `E2E_DEV_BASE_URL`
+  - fallback: `E2E_BASE_URL`
+  - default: `https://teclos.space`
+- browser automation:
+  - Playwright
+
+## Happy Path Scenarios
+
+- dev deployment opens by URL
+- home page renders timer controls and main timer UI
+- productivity page renders tab shell and default todo panel
+- login page renders form fields and submit action
+- each page completes basic navigation without critical browser console errors
+
+## Negative / Edge Scenarios
+
+- blank page, broken route, or failed deploy is a smoke regression
+- missing key UI hooks on any target page is a smoke regression
+- `console.error` or uncaught `pageerror` during base navigation is treated as critical
+- obvious horizontal overflow is treated as a layout-break signal
+
+## Accessibility / UI States
+
+- target UI elements remain visible without interaction
+- productivity default tab state is preserved on first load
+
+## Data / Auth / Storage Notes
+
+- suite is anonymous-only and safe for shared remote environments
+- do not mutate user data in this smoke layer

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -52,3 +52,9 @@ This folder captures browser-level user journeys that should later become execut
 - [07-productivity-notes-and-keyboard-flow.md](07-productivity-notes-and-keyboard-flow.md)
 - [08-cross-tab-sync-and-mini-timer.md](08-cross-tab-sync-and-mini-timer.md)
 - [09-static-and-error-pages-smoke.md](09-static-and-error-pages-smoke.md)
+- [10-dev-deployment-smoke.md](10-dev-deployment-smoke.md)
+
+## Executable Suites
+
+- [login-remote.spec.js](login-remote.spec.js): live login smoke against `teclos.space`
+- [dev-deployment-smoke.spec.js](dev-deployment-smoke.spec.js): remote dev-deployment smoke for `/`, `/productivity`, `/login`

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,46 @@
+# E2E Test Plans
+
+## Purpose
+
+This folder captures browser-level user journeys that should later become executable end-to-end tests.
+
+## Source Surface
+
+- Public pages:
+  - `/`
+  - `/login`
+  - `/about`
+  - `/helpus`
+  - `/productivity`
+- Protected page:
+  - `/user`
+- Session APIs used by the UI:
+  - `/login`
+  - `/api/user/username`
+  - `/api/user/password`
+  - `/api/user/time-settings`
+
+## Automation Notes
+
+- Primary automation layer: Playwright
+- Priority:
+  - `P0` for auth, timer core, settings, user profile, productivity happy paths
+  - `P1` for cross-tab sync and shared UI edge cases
+  - `P2` for static/error-page smoke
+- Test setup must reset:
+  - `pomodoroSettings`
+  - `pomodoroTimerState`
+  - `telos.productivity.v1`
+- Use one dedicated mutable test account for username/password mutation flows
+
+## Plans
+
+- [01-auth-and-route-guards.md](01-auth-and-route-guards.md)
+- [02-home-timer-core-flow.md](02-home-timer-core-flow.md)
+- [03-home-settings-anonymous.md](03-home-settings-anonymous.md)
+- [04-home-settings-authenticated.md](04-home-settings-authenticated.md)
+- [05-user-profile-management.md](05-user-profile-management.md)
+- [06-productivity-todo-flow.md](06-productivity-todo-flow.md)
+- [07-productivity-notes-and-keyboard-flow.md](07-productivity-notes-and-keyboard-flow.md)
+- [08-cross-tab-sync-and-mini-timer.md](08-cross-tab-sync-and-mini-timer.md)
+- [09-static-and-error-pages-smoke.md](09-static-and-error-pages-smoke.md)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -32,6 +32,14 @@ This folder captures browser-level user journeys that should later become execut
   - `pomodoroTimerState`
   - `telos.productivity.v1`
 - Use one dedicated mutable test account for username/password mutation flows
+- Remote smoke target:
+  - `https://teclos.space`
+- Executable remote auth smoke:
+  - [login-remote.spec.js](login-remote.spec.js)
+  - safe-by-default coverage uses anonymous and invalid-credentials flows
+  - successful login is optional and enabled with:
+    - `E2E_LOGIN_USERNAME`
+    - `E2E_LOGIN_PASSWORD`
 
 ## Plans
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -59,3 +59,10 @@ This folder captures browser-level user journeys that should later become execut
 - [login-remote.spec.js](login-remote.spec.js): live login smoke against `teclos.space`
 - [dev-deployment-smoke.spec.js](dev-deployment-smoke.spec.js): remote dev-deployment smoke for `/`, `/productivity`, `/login`
 - [home-timer.spec.js](home-timer.spec.js): remote browser flow for timer start/pause/resume/reset and reload recovery on `/`
+- [negative-browser-flows.spec.js](negative-browser-flows.spec.js): browser-visible negative validation for home settings, login identifier blocking, and productivity forbidden-input handling
+
+## Negative-Test Notes
+
+- Browser negative tests use inline tags like `@ui-negative`.
+- The current negative browser spec intentionally skips on [teclos.space](https://teclos.space) when the deployed assets are known to lag behind the current branch.
+- See [NegativeTestLanes.md](../NegativeTestLanes.md) for lane separation and commands.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -58,3 +58,4 @@ This folder captures browser-level user journeys that should later become execut
 
 - [login-remote.spec.js](login-remote.spec.js): live login smoke against `teclos.space`
 - [dev-deployment-smoke.spec.js](dev-deployment-smoke.spec.js): remote dev-deployment smoke for `/`, `/productivity`, `/login`
+- [home-timer.spec.js](home-timer.spec.js): remote browser flow for timer start/pause/resume/reset and reload recovery on `/`

--- a/tests/e2e/dev-deployment-smoke.spec.js
+++ b/tests/e2e/dev-deployment-smoke.spec.js
@@ -1,0 +1,139 @@
+const { test, expect } = require("@playwright/test");
+
+const baseUrl = process.env.E2E_DEV_BASE_URL || process.env.E2E_BASE_URL || "https://teclos.space";
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function attachConsoleTracking(page) {
+    const criticalMessages = [];
+
+    page.on("console", message => {
+        if (message.type() === "error") {
+            const text = message.text();
+            const isExpectedAnonymousSettings401 =
+                text.includes("Failed to load resource: the server responded with a status of 401");
+
+            if (!isExpectedAnonymousSettings401) {
+                criticalMessages.push(`console.error: ${text}`);
+            }
+        }
+    });
+
+    page.on("pageerror", error => {
+        criticalMessages.push(`pageerror: ${error.message}`);
+    });
+
+    return criticalMessages;
+}
+
+async function expectNoCriticalBrowserErrors(messages, pageName) {
+    expect(
+        messages,
+        `${pageName} should not emit critical browser console errors during smoke navigation`
+    ).toEqual([]);
+}
+
+async function expectLayoutIsStable(page, selectors, pageName) {
+    for (const selector of selectors) {
+        await expect(page.locator(selector), `${pageName} should render ${selector}`).toBeVisible();
+    }
+
+    const hasHorizontalOverflow = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > window.innerWidth + 1;
+    });
+
+    expect(hasHorizontalOverflow, `${pageName} should not have obvious horizontal layout break`).toBe(false);
+}
+
+test.describe("dev deployment smoke", () => {
+    test("home page is available and renders timer UI without critical browser errors", async ({ page }) => {
+        const criticalMessages = attachConsoleTracking(page);
+
+        await page.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
+        await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/?$`));
+
+        await expectLayoutIsStable(
+            page,
+            [
+                ".page-title",
+                "#timerSection",
+                ".timer-modes",
+                "#timeDisplay",
+                "#startBtn",
+                "#resetBtn",
+                "#settingsToggle"
+            ],
+            "Home page"
+        );
+
+        await expectNoCriticalBrowserErrors(criticalMessages, "Home page");
+    });
+
+    test("productivity page is available and renders its primary UI without critical browser errors", async ({ page }) => {
+        const criticalMessages = attachConsoleTracking(page);
+
+        await page.goto(`${baseUrl}/productivity`, { waitUntil: "domcontentloaded" });
+        await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/productivity/?$`));
+
+        await expectLayoutIsStable(page, [".productivity-title"], "Productivity page");
+
+        const hasTabbedUi = await page.locator(".productivity-tabs").count();
+        const hasGuestCard = await page.locator(".productivity-guest-card").count();
+
+        expect(
+            hasTabbedUi > 0 || hasGuestCard > 0,
+            "Productivity page should render either the tabbed workspace or the guest login-required card"
+        ).toBe(true);
+
+        if (hasTabbedUi > 0) {
+            await expectLayoutIsStable(
+                page,
+                [
+                    ".productivity-tabs",
+                    "#productivity-tab-todo",
+                    "#productivity-tab-notes",
+                    '[data-tab-panel="todo"]'
+                ],
+                "Productivity page"
+            );
+
+            await expect(page.locator("#productivity-tab-todo")).toHaveAttribute("aria-selected", "true");
+            await expect(page.locator('[data-tab-panel="todo"]')).toHaveAttribute("aria-hidden", "false");
+        } else {
+            await expectLayoutIsStable(
+                page,
+                [
+                    ".productivity-guest-card",
+                    ".productivity-guest-title",
+                    ".productivity-guest-button"
+                ],
+                "Productivity page"
+            );
+        }
+
+        await expectNoCriticalBrowserErrors(criticalMessages, "Productivity page");
+    });
+
+    test("login page is available and renders auth UI without critical browser errors", async ({ page }) => {
+        const criticalMessages = attachConsoleTracking(page);
+
+        await page.goto(`${baseUrl}/login`, { waitUntil: "domcontentloaded" });
+        await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/login(?:\\?.*)?$`));
+
+        await expectLayoutIsStable(
+            page,
+            [
+                ".auth-title",
+                "#loginForm",
+                "#loginIdentifier",
+                "#loginPassword",
+                ".auth-submit"
+            ],
+            "Login page"
+        );
+
+        await expectNoCriticalBrowserErrors(criticalMessages, "Login page");
+    });
+});

--- a/tests/e2e/home-timer.spec.js
+++ b/tests/e2e/home-timer.spec.js
@@ -1,0 +1,86 @@
+const { test, expect } = require("@playwright/test");
+
+const baseUrl = process.env.E2E_BASE_URL || "https://teclos.space";
+
+function parseTime(value) {
+    const [minutes, seconds] = value.split(":").map(Number);
+    return (minutes * 60) + seconds;
+}
+
+async function openHomeWithCleanTimerState(page) {
+    await page.addInitScript(() => {
+        localStorage.removeItem("pomodoroSettings");
+        localStorage.removeItem("pomodoroTimerState");
+    });
+
+    await page.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
+    await expect(page.locator("#timeDisplay")).toHaveText("25:00");
+}
+
+test.describe("home timer flow", () => {
+    test("timer can start, pause, resume, and reset", async ({ page }) => {
+        await openHomeWithCleanTimerState(page);
+
+        const timeDisplay = page.locator("#timeDisplay");
+        const startButton = page.locator("#startBtn");
+        const startButtonText = startButton.locator(".btn-text");
+        const resetButton = page.locator("#resetBtn");
+
+        await expect(startButtonText).toHaveText("Start");
+
+        await startButton.click();
+        await expect(startButtonText).toHaveText("Pause");
+
+        await page.waitForTimeout(2200);
+        const runningValue = await timeDisplay.textContent();
+        expect(parseTime(runningValue)).toBeLessThan(25 * 60);
+
+        await startButton.click();
+        await expect(startButtonText).toHaveText("Start");
+
+        const pausedValue = await timeDisplay.textContent();
+        await page.waitForTimeout(1500);
+        await expect(timeDisplay).toHaveText(pausedValue);
+
+        await startButton.click();
+        await expect(startButtonText).toHaveText("Pause");
+        await page.waitForTimeout(1500);
+        const resumedValue = await timeDisplay.textContent();
+        expect(parseTime(resumedValue)).toBeLessThan(parseTime(pausedValue));
+
+        await resetButton.click();
+        await expect(startButtonText).toHaveText("Start");
+        await expect(timeDisplay).toHaveText("25:00");
+        await expect(page.locator(".mode-label--active")).toHaveAttribute("data-mode", "pomodoro");
+    });
+
+    test("running timer survives page reload and keeps countdown state", async ({ page }) => {
+        test.skip(
+            baseUrl.includes("teclos.space"),
+            "Known remote issue: the deployed teclos.space home timer resets to 25:00 after reload instead of restoring countdown state."
+        );
+
+        await openHomeWithCleanTimerState(page);
+
+        const timeDisplay = page.locator("#timeDisplay");
+        const startButton = page.locator("#startBtn");
+
+        await startButton.click();
+        await page.waitForTimeout(2200);
+
+        const beforeReload = await timeDisplay.textContent();
+        expect(parseTime(beforeReload)).toBeLessThan(25 * 60);
+
+        await page.reload({ waitUntil: "domcontentloaded" });
+
+        await expect
+            .poll(async () => parseTime(await timeDisplay.textContent()), { timeout: 4000 })
+            .toBeLessThan(25 * 60);
+
+        const afterReload = await timeDisplay.textContent();
+
+        await page.waitForTimeout(1500);
+        const afterReloadTick = await timeDisplay.textContent();
+        expect(parseTime(afterReloadTick)).toBeLessThan(parseTime(afterReload));
+    });
+});

--- a/tests/e2e/login-remote.spec.js
+++ b/tests/e2e/login-remote.spec.js
@@ -1,0 +1,86 @@
+const { test, expect } = require("@playwright/test");
+
+const baseUrl = process.env.E2E_BASE_URL || "https://teclos.space";
+const validUsername = process.env.E2E_LOGIN_USERNAME;
+const validPassword = process.env.E2E_LOGIN_PASSWORD;
+
+async function openLoginPage(page) {
+    await page.goto(`${baseUrl}/login`, { waitUntil: "domcontentloaded" });
+    await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/login(?:\\?.*)?$`));
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+test.describe("teclos.space login smoke", () => {
+    test("login page renders expected server-side form contract", async ({ page }) => {
+        await openLoginPage(page);
+
+        const form = page.locator("#loginForm");
+        const identifierInput = page.locator("#loginIdentifier");
+        const passwordInput = page.locator("#loginPassword");
+        const submitButton = page.locator(".auth-submit");
+
+        await expect(form).toBeVisible();
+        await expect(identifierInput).toBeVisible();
+        await expect(passwordInput).toBeVisible();
+        await expect(form.locator('input[name="username"]')).toHaveCount(1);
+        await expect(form.locator('input[name="password"]')).toHaveCount(1);
+        await expect(form.locator('input[type="hidden"][name="_csrf"]').first()).toHaveAttribute("value", /.+/);
+        await expect(submitButton).toBeVisible();
+        await expect(submitButton).toBeEnabled();
+    });
+
+    test("client-side login validation runs when login-validation.js is deployed", async ({ page }) => {
+        await openLoginPage(page);
+
+        const hasLoginValidationScript = await page.evaluate(() =>
+            Array.from(document.scripts).some(script => script.src.includes("login-validation"))
+        );
+
+        test.skip(!hasLoginValidationScript, "login-validation.js is not deployed on teclos.space yet.");
+
+        const form = page.locator("#loginForm");
+        const identifierError = page.locator('[data-error-for="loginIdentifier"]');
+        const passwordError = page.locator('[data-error-for="loginPassword"]');
+        const formMessage = page.locator("[data-form-message]");
+        const submitButton = page.locator(".auth-submit");
+
+        await expect(submitButton).toBeDisabled();
+        await form.evaluate(formElement => formElement.requestSubmit());
+        await expect(identifierError).toContainText("Email or username is required");
+        await expect(passwordError).toContainText("Password is required");
+        await expect(formMessage).toContainText("Fill in both required fields before continuing.");
+    });
+
+    test("non-empty invalid credentials still submit to the server and stay in login flow", async ({ page }) => {
+        await openLoginPage(page);
+
+        await page.locator("#loginIdentifier").fill("invalid-user");
+        await page.locator("#loginPassword").fill("invalid-password");
+        await page.locator(".auth-submit").click();
+
+        await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/login\\?error(?:=.*)?$`));
+        await expect(page.getByText("Username or password is incorrect")).toBeVisible();
+    });
+
+    test("anonymous user is redirected to login from the protected user page", async ({ page }) => {
+        await page.goto(`${baseUrl}/user`, { waitUntil: "domcontentloaded" });
+
+        await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/login(?:\\?.*)?$`));
+        await expect(page.locator("#loginForm")).toBeVisible();
+    });
+
+    test("valid credentials can still complete the login flow when env vars are provided", async ({ page }) => {
+        test.skip(!validUsername || !validPassword, "Set E2E_LOGIN_USERNAME and E2E_LOGIN_PASSWORD to run the successful-login smoke.");
+
+        await openLoginPage(page);
+
+        await page.locator("#loginIdentifier").fill(validUsername);
+        await page.locator("#loginPassword").fill(validPassword);
+        await page.locator(".auth-submit").click();
+
+        await expect(page).toHaveURL(new RegExp(`${escapeRegExp(baseUrl)}/user(?:\\?.*)?$`));
+    });
+});

--- a/tests/e2e/negative-browser-flows.spec.js
+++ b/tests/e2e/negative-browser-flows.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require("@playwright/test");
+
+const baseUrl = process.env.E2E_BASE_URL || "https://teclos.space";
+
+async function openHomeWithCleanState(page) {
+    await page.addInitScript(() => {
+        localStorage.removeItem("pomodoroSettings");
+        localStorage.removeItem("pomodoroTimerState");
+    });
+
+    await page.goto(`${baseUrl}/`, { waitUntil: "domcontentloaded" });
+}
+
+test.describe("negative browser flows", () => {
+    test("@ui-negative home settings reject invalid numeric values", async ({ page }) => {
+        test.skip(
+            baseUrl.includes("teclos.space"),
+            "This negative browser spec expects the latest branch assets, not the currently deployed remote build."
+        );
+
+        await openHomeWithCleanState(page);
+
+        await page.locator("#settingsToggle").click();
+        await page.locator("#pomodoroTime").fill("abc");
+        await page.locator("#saveSettings").click();
+        await expect(page.locator("#settingsError")).toContainText("Work must be a number.");
+
+        await page.locator("#pomodoroTime").fill("25");
+        await page.locator("#shortBreakTime").fill("2.5");
+        await page.locator("#saveSettings").click();
+        await expect(page.locator("#settingsError")).toContainText("Short break must be a whole number.");
+
+        await page.locator("#shortBreakTime").fill("5");
+        await page.locator("#focusCycles").fill("0");
+        await page.locator("#saveSettings").click();
+        await expect(page.locator("#settingsError")).toContainText("Focus session cycles must be between 1 and 12.");
+    });
+
+    test("@ui-negative login rejects forbidden 67-style identifiers client-side", async ({ page }) => {
+        test.skip(
+            baseUrl.includes("teclos.space"),
+            "This negative browser spec expects the latest branch assets, not the currently deployed remote build."
+        );
+
+        await page.goto(`${baseUrl}/login`, { waitUntil: "domcontentloaded" });
+
+        await page.locator("#loginIdentifier").fill("six seven");
+        await page.locator("#loginPassword").fill("valid-password");
+        await expect(page.locator(".auth-submit")).toBeDisabled();
+        await expect(page.locator('[data-error-for="loginIdentifier"]')).toContainText("67 and six seven are not allowed here.");
+    });
+
+    test("@ui-negative productivity rejects forbidden todo text without breaking layout", async ({ page }) => {
+        test.skip(
+            baseUrl.includes("teclos.space"),
+            "This negative browser spec expects the latest branch assets, not the currently deployed remote build."
+        );
+
+        await page.goto(`${baseUrl}/productivity`, { waitUntil: "domcontentloaded" });
+
+        await page.locator("#todoInput").fill("67");
+        await page.getByRole("button", { name: "Add task" }).click();
+        await expect(page.locator('[data-form-message="todo"]')).toContainText("67 and six seven are not allowed here.");
+        await expect(page.locator('[data-item-list="todo"] li')).toHaveCount(0);
+        await expect(page.locator(".productivity-surface")).toBeVisible();
+    });
+});

--- a/tests/index/README.md
+++ b/tests/index/README.md
@@ -75,3 +75,9 @@
 - [06-settings-panel-fields.md](06-settings-panel-fields.md) — `Playwright`
 - [07-settings-save-cancel-validation.md](07-settings-save-cancel-validation.md) — `Playwright P0`
 - [08-authenticated-settings-sync.md](08-authenticated-settings-sync.md) — `WebMvc API` + `Playwright P0`
+
+## Executable Suites
+
+- [UserTimeSettingsRestControllerTest.java](../../src/test/java/com/example/telos/api/UserTimeSettingsRestControllerTest.java): session API contract coverage for timer settings `GET/PATCH`, including `401`, `403`, validation, and malformed body handling
+- [UserJwtControllerTest.java](../../src/test/java/com/example/telos/api/UserJwtControllerTest.java): JWT API contract coverage for timer settings `GET/PATCH` with bearer auth and invalid-token handling
+- [../e2e/home-timer.spec.js](../e2e/home-timer.spec.js): browser flow for timer start/pause/resume/reset and reload recovery on the home page

--- a/tests/login/05-validation-execution-results.md
+++ b/tests/login/05-validation-execution-results.md
@@ -1,0 +1,38 @@
+# Login Validation Execution Results
+
+## Purpose
+
+Capture the current executable frontend validation coverage for the login page without requiring real authentication integration.
+
+## Source Surface
+
+- Template: [login.html](../../src/main/resources/templates/login.html)
+- Script: [login-validation.js](../../src/main/resources/static/js/login-validation.js)
+- Executable suite: [login-validation.test.mjs](../unit-js/login-validation.test.mjs)
+
+## User Story / Functional Slice
+
+As a user, I see the login form, get immediate required-field validation, and cannot submit an empty form.
+
+## Dependencies
+
+- `#loginForm`
+- `#loginIdentifier`
+- `#loginPassword`
+- field errors:
+  - `data-error-for="loginIdentifier"`
+  - `data-error-for="loginPassword"`
+- form message region `data-form-message`
+- submit button `.auth-submit`
+
+## Execution Result
+
+- Executed locally with:
+  - `node --test tests/unit-js/login-validation.test.mjs`
+- Result:
+  - `3/3` tests passed
+- Covered behaviors:
+  - login form renders with expected fields
+  - submit button is disabled until both fields are filled
+  - empty submit shows field-level error state
+  - valid input passes frontend validation without auth integration

--- a/tests/login/06-remote-smoke-execution-results.md
+++ b/tests/login/06-remote-smoke-execution-results.md
@@ -1,0 +1,49 @@
+# Remote Login Smoke Execution Results
+
+## Purpose
+
+Record the live-site smoke result for the login page against `https://teclos.space`.
+
+## Executed Suite
+
+- [../e2e/login-remote.spec.js](../e2e/login-remote.spec.js)
+
+## Executed Coverage
+
+- login page renders with the expected form hooks:
+  - `#loginForm`
+  - `#loginIdentifier`
+  - `#loginPassword`
+- client-side validation blocks empty submit and surfaces field/form error state
+- non-empty invalid credentials still pass through to the server and return to the login flow with the server-side error message
+- anonymous navigation to `/user` redirects back to `/login`
+
+## Optional Coverage
+
+- successful login redirect to `/user` is implemented in the same Playwright suite
+- this scenario is intentionally gated behind:
+  - `E2E_LOGIN_USERNAME`
+  - `E2E_LOGIN_PASSWORD`
+- the live smoke stays safe by default and does not require a mutable shared account
+
+## Result
+
+- Execution date: `2026-04-08`
+- Result status: passed with skips
+- Target URL: `https://teclos.space`
+- Command:
+  - `npx playwright test tests/e2e/login-remote.spec.js --reporter=line`
+- Outcome:
+  - `3 passed`
+  - `2 skipped`
+- Passed scenarios:
+  - login page renders expected server-side form contract
+  - non-empty invalid credentials reach the server and stay in the login flow with the server-side error message
+  - anonymous access to `/user` redirects back to `/login`
+- Skipped scenarios:
+  - client-side login validation on the live site
+  - successful login redirect with valid credentials
+- Notes:
+  - `login-validation.js` is not currently deployed on `teclos.space/login`, so the live smoke cannot yet verify the new client-side disabled/error-state behavior there
+  - the successful-login case is implemented but intentionally requires `E2E_LOGIN_USERNAME` and `E2E_LOGIN_PASSWORD`
+  - the current live login form contains two hidden `_csrf` inputs; the smoke was made tolerant to this actual DOM shape

--- a/tests/login/README.md
+++ b/tests/login/README.md
@@ -44,6 +44,8 @@
 
 - [login-validation.test.mjs](../unit-js/login-validation.test.mjs): required fields, disabled submit state, client-side error state
 - [05-validation-execution-results.md](05-validation-execution-results.md): executed frontend validation result
+- [../e2e/login-remote.spec.js](../e2e/login-remote.spec.js): live `teclos.space` smoke for login form rendering, invalid submit, protected-route redirect, optional successful login
+- [06-remote-smoke-execution-results.md](06-remote-smoke-execution-results.md): executed remote login smoke result
 
 ## Plans
 

--- a/tests/login/README.md
+++ b/tests/login/README.md
@@ -13,7 +13,8 @@
 - Session auth entrypoint: `POST /login`
 - Security redirect target: `/user`
 - CSRF hidden form field
-- No page-owned JavaScript file
+- Page script:
+  - [login-validation.js](../../src/main/resources/static/js/login-validation.js)
 
 ## Covered Blocks
 
@@ -21,6 +22,7 @@
 - login form fields and CSRF
 - successful login and redirect
 - error states for invalid credentials
+- frontend validation execution results
 
 ## Automation Notes
 
@@ -36,6 +38,12 @@
   - GET `/login` smoke
   - valid login redirect to `/user`
   - invalid credentials stay in login flow with error message
+  - frontend required-field validation without auth integration
+
+## Executable Suites
+
+- [login-validation.test.mjs](../unit-js/login-validation.test.mjs): required fields, disabled submit state, client-side error state
+- [05-validation-execution-results.md](05-validation-execution-results.md): executed frontend validation result
 
 ## Plans
 
@@ -43,3 +51,4 @@
 - [02-login-form-fields-and-csrf.md](02-login-form-fields-and-csrf.md) — `WebMvc`
 - [03-login-success-and-redirect.md](03-login-success-and-redirect.md) — `integration` + `Playwright P0`
 - [04-login-error-and-invalid-credentials.md](04-login-error-and-invalid-credentials.md) — `integration` + `Playwright P0`
+- [05-validation-execution-results.md](05-validation-execution-results.md) — executed JS frontend suite

--- a/tests/login/README.md
+++ b/tests/login/README.md
@@ -42,6 +42,7 @@
 
 ## Executable Suites
 
+- [AuthJwtControllerTest.java](../../src/test/java/com/example/telos/api/AuthJwtControllerTest.java): JWT login contract coverage for valid and invalid credential paths
 - [login-validation.test.mjs](../unit-js/login-validation.test.mjs): required fields, disabled submit state, client-side error state
 - [05-validation-execution-results.md](05-validation-execution-results.md): executed frontend validation result
 - [../e2e/login-remote.spec.js](../e2e/login-remote.spec.js): live `teclos.space` smoke for login form rendering, invalid submit, protected-route redirect, optional successful login

--- a/tests/manual/01-core-flows-regression-checklist.md
+++ b/tests/manual/01-core-flows-regression-checklist.md
@@ -1,0 +1,87 @@
+# Core Flows Manual Regression Checklist
+
+## Scope
+
+Reusable manual regression checklist for the primary user flows that should be verified before demos, release candidates, and important dev deployments.
+
+## Execution Metadata
+
+- Date:
+- Environment:
+- Base URL:
+- Browser:
+- Tester:
+- Build / commit:
+- Overall result:
+
+## Status Legend
+
+- `PASS`
+- `FAIL`
+- `BLOCKED`
+- `N/A`
+
+## Preconditions
+
+- Start in a clean browser session or incognito window.
+- If possible, clear:
+  - `pomodoroSettings`
+  - `pomodoroTimerState`
+  - `telos.productivity.v1`
+- Use one anonymous session and, when available, one authenticated session.
+- Verify the target environment URL before starting the run.
+
+## Checklist
+
+| ID | Area | Check | Expected Result | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| CF-01 | Deployment | Open the base URL in a fresh session. | The site loads successfully and the main shell renders without a blank screen or obvious layout break. |  |  |
+| CF-02 | Home / Timer | Open `/` and verify the timer page shell. | Header, timer section, timer mode labels, time display, start button, reset button, and settings button are visible. |  |  |
+| CF-03 | Timer | Click `Start`. | The timer enters running state, the visible countdown starts decreasing, and the start button changes to the running/pause state. |  |  |
+| CF-04 | Timer | While running, click the pause control. | The timer stops decreasing, remains on the current mode, and reflects a paused state instead of continuing to run. |  |  |
+| CF-05 | Timer | After start or pause, click `Reset`. | The timer returns to its default state, the default mode is restored, and the main display returns to the starting duration. |  |  |
+| CF-06 | Timer / Persistence | Start the timer, wait a few seconds, then reload the page. | The timer restores from storage and does not lose the current session state. Running timers continue with updated remaining time; paused timers remain paused. |  |  |
+| CF-07 | Timer / Navigation | Start or pause the timer on `/`, then navigate to another public page such as `/about` or `/productivity`. | Navigation works normally, the app shell remains intact, and timer-related state is not unexpectedly reset. |  |  |
+| CF-08 | Mini Timer | On a non-home page, verify the mini timer visibility. | The mini timer is visible where expected, shows the current mode and time, and reflects ready/running/paused state consistently with the main timer. |  |  |
+| CF-09 | Mini Timer / Navigation | Change timer state on `/`, then navigate between pages. | The mini timer remains in sync without requiring a manual browser refresh. |  |  |
+| CF-10 | Productivity | Open `/productivity` in the target environment. | The page renders its primary UI variant correctly for the current auth state, without broken layout or blank content. |  |  |
+| CF-11 | Productivity Tabs | If the tabbed productivity UI is available, switch between `To-do` and `Notes`. | Tabs switch within the same route, the active state updates correctly, and the matching content panel is shown. |  |  |
+| CF-12 | Productivity Layout | While switching productivity tabs, watch the layout. | The page layout remains stable and controls do not overlap, jump unexpectedly, or disappear. |  |  |
+| CF-13 | Login | Open `/login`. | The login page renders correctly with visible identifier field, password field, and submit button. |  |  |
+| CF-14 | Login | If the environment supports it, attempt one invalid login. | The page stays in the login flow and shows a visible error state instead of a broken page or silent failure. |  |  |
+| CF-15 | User / Profile | Open `/user` or the environment’s profile route using an authenticated session. | The user/profile page renders successfully and shows the expected profile sections instead of an error page or broken layout. |  |  |
+| CF-16 | User / Profile | Inspect the profile page sections. | Profile data and password-change sections are visible and usable in the current UI. |  |  |
+| CF-17 | Cross-page Shell | During the full pass, check header and footer consistency. | Header navigation, footer content, and shared layout remain consistent across the visited pages. |  |  |
+| CF-18 | Browser Errors | During the full pass, watch for obvious runtime failures. | No critical browser-visible errors, raw exception pages, or blocking UI failures appear during the smoke path. |  |  |
+
+## Recommended Execution Order
+
+1. Base URL and home page shell
+2. Timer start, pause, reset
+3. Timer reload recovery
+4. Cross-page navigation and mini timer
+5. Productivity page and tab switching
+6. Login page rendering
+7. User/profile page rendering
+
+## Failure Logging Notes
+
+- For timer failures, record:
+  - current mode
+  - whether the timer was running or paused
+  - whether the issue appeared before or after reload
+- For productivity failures, record:
+  - authenticated or anonymous state
+  - whether the page showed tabs or a guest/login-required variant
+- For login/profile failures, record:
+  - route visited
+  - visible error message
+  - whether the issue is reproducible in a fresh session
+
+## Related Detailed Plans
+
+- [../index/04-timer-controls-start-pause-reset.md](../index/04-timer-controls-start-pause-reset.md)
+- [../mini-timer-scripts/02-mini-timer-runtime-contract.md](../mini-timer-scripts/02-mini-timer-runtime-contract.md)
+- [../productivity/01-page-shell-and-tabs.md](../productivity/01-page-shell-and-tabs.md)
+- [../login/README.md](../login/README.md)
+- [../user/README.md](../user/README.md)

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,25 @@
+# Manual Regression Checklists
+
+## Purpose
+
+This folder contains reusable manual checklists for demo, staging, and pre-release regression passes.
+
+## How To Use
+
+- Pick the checklist that matches the scope of the run.
+- Record the execution date, environment URL, tester name, and result next to each item.
+- Mark each item as:
+  - `PASS`
+  - `FAIL`
+  - `BLOCKED`
+  - `N/A`
+- If an item fails, add the observed behavior, browser, and reproduction notes.
+
+## Available Checklists
+
+- [01-core-flows-regression-checklist.md](01-core-flows-regression-checklist.md)
+
+## Notes
+
+- These checklists are intended for repeated use before demos and releases.
+- Keep them lightweight and execution-oriented; deeper edge-case coverage lives in the page and E2E plans under `tests/`.

--- a/tests/mini-timer-scripts/README.md
+++ b/tests/mini-timer-scripts/README.md
@@ -40,6 +40,14 @@
   - storage-driven updates
   - authenticated sync side effects
 
+## Executable Coverage
+
+- [mini-timer.test.mjs](../unit-js/mini-timer.test.mjs) now validates:
+  - persisted running state hydration
+  - mode/time/status mirroring after `timer:state-updated`
+  - storage-driven updates without reload
+  - state continuity across a new page bootstrap with shared storage
+
 ## Plans
 
 - [01-script-injection-order.md](01-script-injection-order.md) — `Playwright smoke`

--- a/tests/productivity/01-page-shell-and-tabs.md
+++ b/tests/productivity/01-page-shell-and-tabs.md
@@ -29,12 +29,14 @@ As a user, I can open the Productivity page, understand its purpose, and switch 
 - todo tab is active by default
 - notes tab is inactive by default
 - clicking each tab updates active styles and visible panel
+- current implementation exposes two tabs only: `To-do` and `Notes`
 
 ## Negative / Edge Scenarios
 
 - both panels must not be simultaneously active by default
 - both tabs must not show `aria-selected="true"` at the same time
 - missing tab-to-panel mapping is a regression
+- a `Reminders` tab is not present in the current template and should be treated as out of scope until implemented
 
 ## Accessibility / UI States
 

--- a/tests/productivity/08-tab-behavior-execution-results.md
+++ b/tests/productivity/08-tab-behavior-execution-results.md
@@ -1,0 +1,60 @@
+# Productivity Tab Behavior Execution Results
+
+## Purpose
+
+Record the current implementation scope and the executed frontend test coverage for productivity tab switching.
+
+## Source Surface
+
+- Template: [productivity.html](../../src/main/resources/templates/productivity.html)
+- Script: [productivity.js](../../src/main/resources/static/js/productivity.js)
+- Executable suite: [productivity-tabs.test.mjs](../unit-js/productivity-tabs.test.mjs)
+
+## User Story / Functional Slice
+
+As a user, I can see the available productivity tabs, switch between them on the same page, and view the matching panel content without breaking the page shell.
+
+## Dependencies
+
+- `data-tab-trigger`
+- `data-tab-panel`
+- current route `/productivity`
+- client-side tab switching in `productivity.js`
+
+## Happy Path Scenarios
+
+- current implementation renders `To-do` and `Notes` tabs
+- `To-do` is active on initial load
+- clicking `Notes` activates the notes tab and reveals the notes panel
+- clicking back to `To-do` restores the original state
+- tab switching does not change `location.pathname`
+
+## Negative / Edge Scenarios
+
+- as of 2026-04-08, no `Reminders` tab exists in the actual template, so it is not covered as executable behavior
+- inactive and active tabs must not both expose `aria-selected="true"`
+- hidden and visible panels must not both be active at once
+
+## Accessibility / UI States
+
+- active tab state is synchronized through `productivity-tab--active`
+- `aria-selected`, `aria-controls`, and `aria-hidden` stay aligned with the visible panel
+- tab switching keeps panel structure intact instead of re-routing
+
+## Data / Auth / Storage Notes
+
+- tab switching is client-side only
+- no backend API is involved
+- storage is not required for the basic tab-behavior checks
+
+## Execution Result
+
+- Executed locally with:
+  - `node --test tests/unit-js/productivity-tabs.test.mjs`
+- Result:
+  - `3/3` tests passed
+- Covered by executable assertions:
+  - available tabs are present
+  - active state changes correctly
+  - matching panel visibility changes correctly
+  - route does not change during tab switching

--- a/tests/productivity/09-executable-coverage-results.md
+++ b/tests/productivity/09-executable-coverage-results.md
@@ -1,0 +1,75 @@
+# Productivity Executable Coverage Results
+
+## Purpose
+
+Summarize the current executable test coverage for the productivity page and tie it back to the split README plan.
+
+## Source Surface
+
+- Template: [productivity.html](../../src/main/resources/templates/productivity.html)
+- Script: [productivity.js](../../src/main/resources/static/js/productivity.js)
+- Executable suites:
+  - [productivity-tabs.test.mjs](../unit-js/productivity-tabs.test.mjs)
+  - [productivity-interactions.test.mjs](../unit-js/productivity-interactions.test.mjs)
+  - [productivity-storage.test.mjs](../unit-js/productivity-storage.test.mjs)
+
+## User Story / Functional Slice
+
+As a user, I can use the productivity page tabs, manage todos and notes, rely on browser storage, and keep a stable single-page workflow without route changes.
+
+## Dependencies
+
+- `telos.productivity.v1`
+- `data-tab-trigger`
+- `data-tab-panel`
+- `data-entry-form`
+- `data-item-list`
+- `data-empty-state`
+- `data-form-message`
+- list action hooks through `data-action`
+
+## Happy Path Scenarios
+
+- tabs render and switch between `To-do` and `Notes`
+- todo form creates tasks and hides the empty state
+- todo items support complete, edit, keyboard save, cancel, and delete
+- notes form creates notes and hides the empty state
+- notes support edit, modifier-key save, and delete
+- existing storage data hydrates the page correctly
+- cross-tab storage sync refreshes a second productivity page instance
+
+## Negative / Edge Scenarios
+
+- blank todo and note submissions show invalid state and inline errors
+- malformed storage records are filtered during normalization
+- corrupted storage JSON falls back to a safe empty state
+- note content is escaped instead of executing HTML/script payloads
+- plain `Enter` on note editing does not save without modifier keys
+- current implementation has no `Reminders` tab, so that behavior remains out of scope until implemented
+
+## Accessibility / UI States
+
+- active tabs keep `aria-selected` and `aria-hidden` synchronized
+- tab switching does not change the route
+- focused editors are preserved during edit mode
+- invalid fields expose `aria-invalid`
+
+## Data / Auth / Storage Notes
+
+- productivity page is fully browser-storage driven in the current implementation
+- no backend API is involved in the covered runtime behavior
+
+## Execution Result
+
+- Executed locally with:
+  - `node --test tests/unit-js/productivity-tabs.test.mjs tests/unit-js/productivity-interactions.test.mjs tests/unit-js/productivity-storage.test.mjs`
+- Result:
+  - `12/12` tests passed
+- Covered README blocks:
+  - page shell and tabs
+  - todo form and empty state
+  - todo item lifecycle
+  - notes form and empty state
+  - note item lifecycle
+  - local storage and cross-tab sync
+  - keyboard and accessibility states

--- a/tests/productivity/README.md
+++ b/tests/productivity/README.md
@@ -26,6 +26,7 @@
 - note item lifecycle
 - local storage and cross-tab sync
 - keyboard and accessibility states
+- tab behavior execution results
 
 ## Related Shared Docs
 
@@ -55,6 +56,13 @@
   - localStorage persistence
   - cross-tab sync
 
+## Executable Suites
+
+- [productivity-tabs.test.mjs](../unit-js/productivity-tabs.test.mjs): tabs, active state, panel visibility, no-route-change behavior
+- [productivity-interactions.test.mjs](../unit-js/productivity-interactions.test.mjs): todo and note forms, empty states, edit/delete flows, keyboard save behavior, invalid states
+- [productivity-storage.test.mjs](../unit-js/productivity-storage.test.mjs): storage hydration, malformed storage fallback, cross-tab sync
+- [09-executable-coverage-results.md](09-executable-coverage-results.md): consolidated executed result for current productivity coverage
+
 ## Plans
 
 - [01-page-shell-and-tabs.md](01-page-shell-and-tabs.md) — `Playwright smoke`
@@ -64,3 +72,5 @@
 - [05-note-item-lifecycle.md](05-note-item-lifecycle.md) — `Playwright P0`
 - [06-local-storage-and-cross-tab-sync.md](06-local-storage-and-cross-tab-sync.md) — `Playwright P1`
 - [07-keyboard-and-a11y-states.md](07-keyboard-and-a11y-states.md) — `Playwright P1`
+- [08-tab-behavior-execution-results.md](08-tab-behavior-execution-results.md) — executed JS frontend suite
+- [09-executable-coverage-results.md](09-executable-coverage-results.md) — consolidated executable productivity coverage

--- a/tests/unit-java/01-user-service.md
+++ b/tests/unit-java/01-user-service.md
@@ -1,0 +1,67 @@
+# UserServiceImpl Unit Scenarios
+
+## Purpose
+
+Define unit scenarios for `UserServiceImpl` so username, password, and repository interaction rules are covered without HTTP or browser layers.
+
+## Source Surface
+
+- [UserServiceImpl.java](../../src/main/java/com/example/telos/service/impl/UserServiceImpl.java)
+
+## User Story / Functional Slice
+
+As the service layer, user lookup and profile mutation logic must enforce null checks, uniqueness rules, and password rules consistently.
+
+## Dependencies
+
+- mocked `UserRepository`
+- mocked `PasswordEncoder`
+- DTOs:
+  - `UserPasswordDto`
+  - `UserUsernameResponseDto`
+  - `UserPasswordResponseDto`
+
+## Happy Path Scenarios
+
+- `findById` returns user when repository finds one
+- `findByEmail` returns user when repository finds one
+- `findByUsername` returns user when repository finds one
+- `findByEmailOrUsername` returns user when repository finds one
+- `create` saves a non-null user
+- `update` saves an existing user with non-null `userId`
+- `delete` deletes an existing user with non-null `userId`
+- `findAll` returns repository result
+- `updateUsername` trims input and returns success DTO
+- `updateUsername` allows saving the same username for the same user
+- `updatePassword` encodes new password and returns success DTO
+
+## Negative / Edge Scenarios
+
+- `findById` throws `EntityNotFoundException` when missing
+- `findByEmail` throws `EntityNotFoundException` when missing
+- `findByUsername` throws `EntityNotFoundException` when missing
+- `findByEmailOrUsername` throws `EntityNotFoundException` when missing
+- `create(null)` throws `NullEntityReferenceException`
+- `update(null)` throws `NullEntityReferenceException`
+- `update` with null `userId` throws `NullEntityReferenceException`
+- `delete(null)` throws `NullEntityReferenceException`
+- `delete` with null `userId` throws `NullEntityReferenceException`
+- `updateUsername` with null/blank username throws `NullEntityReferenceException`
+- `updateUsername` with another user already owning that username throws `UsernameAlreadyTakenException`
+- `updatePassword(null dto)` throws `NullEntityReferenceException`
+- `updatePassword` with any null password field throws `NullEntityReferenceException`
+- `updatePassword` with mismatched new/confirm passwords throws `IllegalArgumentException`
+- `updatePassword` with wrong old password throws `IllegalArgumentException`
+
+## Accessibility / UI States
+
+- Not applicable at the pure service layer
+
+## Data / Auth / Storage Notes
+
+- Treat login lookup as a service input, not an HTTP principal concern
+- Verify repository interactions precisely:
+  - save called once on success
+  - delete called once on success
+  - no save on validation failure
+- Verify password encoding happens only after old password match succeeds

--- a/tests/unit-java/02-user-time-settings-service.md
+++ b/tests/unit-java/02-user-time-settings-service.md
@@ -1,0 +1,61 @@
+# UserTimeSettingsServiceImpl Unit Scenarios
+
+## Purpose
+
+Define unit scenarios for time-settings business logic without HTTP or browser concerns.
+
+## Source Surface
+
+- [UserTimeSettingsServiceImpl.java](../../src/main/java/com/example/telos/service/impl/UserTimeSettingsServiceImpl.java)
+
+## User Story / Functional Slice
+
+As the service layer, user time settings must be retrievable and updatable consistently for the current user.
+
+## Dependencies
+
+- mocked `UserTimeSettingsRepository`
+- mocked `UserService`
+- DTOs:
+  - `UserTimeSettingsDto`
+  - `UserTimeSettingsResponseDto`
+
+## Happy Path Scenarios
+
+- `findById` returns settings when repository finds one
+- `create` saves non-null settings
+- `update` saves existing settings with non-null `settingsId`
+- `delete` deletes settings with non-null `settingsId`
+- `findByUser` returns settings for existing user with `userId`
+- `findAll` returns repository result
+- `updateSettings` updates all mutable fields and returns response DTO
+- `findSettings` returns a DTO matching persisted values
+
+## Negative / Edge Scenarios
+
+- `findById` throws `EntityNotFoundException` when missing
+- `create(null)` throws `NullEntityReferenceException`
+- `update(null)` throws `NullEntityReferenceException`
+- `update` with null `settingsId` throws `NullEntityReferenceException`
+- `delete(null)` throws `NullEntityReferenceException`
+- `delete` with null `settingsId` throws `NullEntityReferenceException`
+- `findByUser(null)` throws `NullEntityReferenceException`
+- `findByUser` with null `userId` throws `NullEntityReferenceException`
+- `findByUser` throws `EntityNotFoundException` when settings record is missing
+- `updateSettings` fails when user lookup fails
+- `updateSettings` fails when looked-up user has null `userId`
+- `findSettings` fails when looked-up user has null `userId`
+
+## Accessibility / UI States
+
+- Not applicable at the pure service layer
+
+## Data / Auth / Storage Notes
+
+- Verify that `updateSettings` persists:
+  - `pomodoroMinutes`
+  - `shortBreakMinutes`
+  - `longBreakMinutes`
+  - `pomoCycles`
+  - `soundsEnabled`
+- Verify no hidden fallback or partial-save behavior is assumed

--- a/tests/unit-java/03-log-error-service.md
+++ b/tests/unit-java/03-log-error-service.md
@@ -1,0 +1,45 @@
+# LogErrorServiceImpl Unit Scenarios
+
+## Purpose
+
+Define unit scenarios for error logging rules and persistence boundaries.
+
+## Source Surface
+
+- [LogErrorServiceImpl.java](../../src/main/java/com/example/telos/service/impl/LogErrorServiceImpl.java)
+
+## User Story / Functional Slice
+
+As the logging service, warn-level events should log without DB persistence, while 5xx errors should attempt persistence without breaking the main flow.
+
+## Dependencies
+
+- mocked `LogErrorRepository`
+- mocked `HttpServletRequest`
+- exception instance
+
+## Happy Path Scenarios
+
+- `logWarn` builds description from request method, path, and exception type
+- `logWarn` does not persist to repository
+- `logError` builds the same description format
+- `logError` persists an `ErrorLog` for 5xx status
+- persisted `ErrorLog` contains:
+  - `httpError`
+  - `errorDescription`
+
+## Negative / Edge Scenarios
+
+- `logError` for 4xx status does not persist
+- repository failure during `logError` persistence is swallowed and does not rethrow
+- unusual exception types still produce a compact description string
+
+## Accessibility / UI States
+
+- Not applicable at the pure service layer
+
+## Data / Auth / Storage Notes
+
+- Expected description format:
+  - `status=<code>, method=<verb>, path=<uri>, exception=<type>`
+- This unit should verify repository interactions rather than SLF4J output text

--- a/tests/unit-java/04-jwt-service.md
+++ b/tests/unit-java/04-jwt-service.md
@@ -1,0 +1,45 @@
+# JwtService Unit Scenarios
+
+## Purpose
+
+Define pure unit scenarios for token generation, claim extraction, and validity rules.
+
+## Source Surface
+
+- [JwtService.java](../../src/main/java/com/example/telos/security/JwtService.java)
+
+## User Story / Functional Slice
+
+As the JWT helper, token generation and validation must be deterministic and safe for downstream authentication logic.
+
+## Dependencies
+
+- valid base64 secret
+- configurable `jwt.expiration`
+- mocked or simple `UserDetails`
+
+## Happy Path Scenarios
+
+- constructor accepts valid base64 secret of sufficient length
+- `generateToken` creates a signed token with subject equal to the provided login
+- generated token has `issuedAt`
+- generated token has expiration after issue time
+- `extractLogin` returns token subject
+- `isTokenValid` returns true when token subject matches user details username and token is not expired
+
+## Negative / Edge Scenarios
+
+- invalid base64 secret fails fast during service construction
+- too-short decoded secret fails key creation
+- `isTokenValid` returns false when token subject does not match user details username
+- expired token is treated as invalid
+- malformed token passed to claim extraction raises parser failure
+
+## Accessibility / UI States
+
+- Not applicable at the pure service layer
+
+## Data / Auth / Storage Notes
+
+- Token subject currently stores the user email for downstream auth
+- Keep expiration assertions tolerant to clock drift in implementation

--- a/tests/unit-java/05-jwt-filter.md
+++ b/tests/unit-java/05-jwt-filter.md
@@ -1,0 +1,48 @@
+# JwtFilter Unit Scenarios
+
+## Purpose
+
+Define unit scenarios for request filtering and security-context population in `JwtFilter`.
+
+## Source Surface
+
+- [JwtFilter.java](../../src/main/java/com/example/telos/security/JwtFilter.java)
+
+## User Story / Functional Slice
+
+As the JWT request filter, bearer-token requests should populate authentication when valid and short-circuit with `401` when the token is malformed or expired.
+
+## Dependencies
+
+- mocked `UserDetailsService`
+- mocked `JwtService`
+- mocked `RestAuthenticationEntryPoint`
+- mocked request, response, and filter chain
+- `SecurityContextHolder`
+
+## Happy Path Scenarios
+
+- missing `Authorization` header passes request through unchanged
+- non-bearer `Authorization` header passes request through unchanged
+- valid bearer token extracts login, loads user details, validates token, and sets authentication in `SecurityContextHolder`
+- valid token continues the filter chain
+- already-authenticated security context does not get overwritten unnecessarily
+
+## Negative / Edge Scenarios
+
+- `JwtException` during token extraction clears context and invokes `restAuthenticationEntryPoint`
+- `IllegalArgumentException` during token handling clears context and invokes `restAuthenticationEntryPoint`
+- invalid token must not continue the filter chain after entry point handles the error
+- token mismatch with loaded user details must not authenticate the request
+
+## Accessibility / UI States
+
+- Not applicable at the pure filter layer
+
+## Data / Auth / Storage Notes
+
+- Unit implementation should reset `SecurityContextHolder` before and after each test
+- Verify:
+  - filter chain interaction count
+  - entry point invocation count
+  - authentication presence/absence in context

--- a/tests/unit-java/README.md
+++ b/tests/unit-java/README.md
@@ -29,3 +29,10 @@ This folder captures pure Java unit-level scenario coverage that should later be
 - [03-log-error-service.md](03-log-error-service.md)
 - [04-jwt-service.md](04-jwt-service.md)
 - [05-jwt-filter.md](05-jwt-filter.md)
+
+## Executable Suites
+
+- [UserServiceImplTest.java](../../src/test/java/com/example/telos/service/UserServiceImplTest.java): username trimming/conflict handling, password validation, password encoding
+- [UserTimeSettingsServiceImplTest.java](../../src/test/java/com/example/telos/service/UserTimeSettingsServiceImplTest.java): settings lookup, field updates, persistence handoff, null-user guards
+- [JwtServiceTest.java](../../src/test/java/com/example/telos/security/JwtServiceTest.java): token generation, claim extraction, expiry behavior, malformed-token handling
+- [JwtFilterTest.java](../../src/test/java/com/example/telos/security/JwtFilterTest.java): bearer header handling, security-context population, invalid-token short-circuit behavior

--- a/tests/unit-java/README.md
+++ b/tests/unit-java/README.md
@@ -1,0 +1,31 @@
+# Java Unit Test Plans
+
+## Purpose
+
+This folder captures pure Java unit-level scenario coverage that should later be implemented without full MVC or browser overhead.
+
+## Source Surface
+
+- Services:
+  - [UserServiceImpl.java](../../src/main/java/com/example/telos/service/impl/UserServiceImpl.java)
+  - [UserTimeSettingsServiceImpl.java](../../src/main/java/com/example/telos/service/impl/UserTimeSettingsServiceImpl.java)
+  - [LogErrorServiceImpl.java](../../src/main/java/com/example/telos/service/impl/LogErrorServiceImpl.java)
+- Security:
+  - [JwtService.java](../../src/main/java/com/example/telos/security/JwtService.java)
+  - [JwtFilter.java](../../src/main/java/com/example/telos/security/JwtFilter.java)
+
+## Automation Notes
+
+- Primary automation layer: JUnit + Mockito
+- Priority: `P0` for `UserServiceImpl`, `UserTimeSettingsServiceImpl`, `JwtService`
+- Priority: `P1` for `JwtFilter`, `LogErrorServiceImpl`
+- Keep these tests isolated from Spring context unless behavior cannot be exercised meaningfully without it
+- Prefer fixed clock-like assertions where possible for token semantics and deterministic expectations
+
+## Plans
+
+- [01-user-service.md](01-user-service.md)
+- [02-user-time-settings-service.md](02-user-time-settings-service.md)
+- [03-log-error-service.md](03-log-error-service.md)
+- [04-jwt-service.md](04-jwt-service.md)
+- [05-jwt-filter.md](05-jwt-filter.md)

--- a/tests/unit-js/01-timer-state-normalization-and-storage.md
+++ b/tests/unit-js/01-timer-state-normalization-and-storage.md
@@ -1,0 +1,53 @@
+# Timer State Normalization And Storage Scenarios
+
+## Purpose
+
+Define JS unit scenarios for settings/state normalization and storage-facing behavior in `timer-state.js`.
+
+## Source Surface
+
+- [timer-state.js](../../src/main/resources/static/js/timer-state.js)
+
+## User Story / Functional Slice
+
+As the shared timer state module, the code must normalize malformed input and persist safe values to browser storage.
+
+## Dependencies
+
+- `localStorage`
+- exported `window.PomodoroTimerState`
+
+## Happy Path Scenarios
+
+- default settings normalize to `25/5/15/true/1`
+- valid numeric settings are preserved
+- `getSettingsKey` maps:
+  - `pomodoro -> pomodoro`
+  - `short-break -> shortBreak`
+  - `long-break -> longBreak`
+- `getDefaultTimerState` returns idle pomodoro state
+- `saveSettings` writes normalized settings to `pomodoroSettings`
+- `saveTimerState` writes normalized timer state to `pomodoroTimerState`
+- `loadSettings` returns parsed saved settings
+- `loadTimerState` returns parsed saved timer state when valid
+
+## Negative / Edge Scenarios
+
+- invalid numbers are clamped or replaced by fallback values
+- `soundEnabled` defaults to true unless explicitly false
+- corrupted `pomodoroSettings` JSON falls back to defaults
+- corrupted `pomodoroTimerState` JSON falls back to default timer state
+- invalid mode in stored timer state falls back to `pomodoro`
+- negative remaining seconds are normalized away
+- idle break state loaded from storage resets to default pomodoro state
+
+## Accessibility / UI States
+
+- Not applicable at the pure state-module layer
+
+## Data / Auth / Storage Notes
+
+- Keys under test:
+  - `pomodoroSettings`
+  - `pomodoroTimerState`
+- This suite should avoid DOM dependencies and focus on pure state/storage transitions

--- a/tests/unit-js/02-timer-state-transitions-and-projections.md
+++ b/tests/unit-js/02-timer-state-transitions-and-projections.md
@@ -1,0 +1,50 @@
+# Timer State Transitions And Projections Scenarios
+
+## Purpose
+
+Define JS unit scenarios for timer progression, session completion, and projected end-time logic.
+
+## Source Surface
+
+- [timer-state.js](../../src/main/resources/static/js/timer-state.js)
+
+## User Story / Functional Slice
+
+As the timer state engine, the module must move between work/break phases correctly and compute derived values safely.
+
+## Dependencies
+
+- fixed timestamps in tests
+- exported timer-state helpers
+
+## Happy Path Scenarios
+
+- `startTimerState` starts a fresh pomodoro timer
+- `pauseTimerState` freezes a running timer at the correct remaining value
+- `resetTimerState` returns fresh pomodoro state
+- `setModeState` switches into requested valid mode and resets end-time
+- `applySettingsToTimerState` recomputes remaining time for paused state
+- `getCurrentPomodoroNumber` returns expected pomodoro number across cycle states
+- `getCurrentFocusCycleNumber` returns expected focus cycle number
+- `hydrateTimerState` advances completed pomodoro into short break
+- `hydrateTimerState` advances fourth pomodoro into long break
+- `hydrateTimerState` advances completed long break into next focus cycle or final stopped state
+- `getProjectedSessionEndTime` returns a future end time for in-progress or startable sessions
+- `isFocusSessionFinished` returns true only for terminal completed state
+- `areStatesEqual` returns true only for field-identical states
+
+## Negative / Edge Scenarios
+
+- calling `startTimerState` on already-running state returns a consistent running state
+- invalid mode passed to `setModeState` normalizes instead of corrupting state
+- hydrate guard prevents runaway loops on pathological input
+- projected end time returns `null` when the session is already finished
+
+## Accessibility / UI States
+
+- Not applicable at the pure state-module layer
+
+## Data / Auth / Storage Notes
+
+- This suite should stub time explicitly rather than rely on wall clock
+- P0 because browser timer behavior depends heavily on these transitions

--- a/tests/unit-js/03-productivity-storage-and-sanitization.md
+++ b/tests/unit-js/03-productivity-storage-and-sanitization.md
@@ -1,0 +1,50 @@
+# Productivity Storage And Sanitization Scenarios
+
+## Purpose
+
+Define JS unit-like scenarios for the pure logic portions inside `productivity.js`, especially storage normalization and escaping.
+
+## Source Surface
+
+- [productivity.js](../../src/main/resources/static/js/productivity.js)
+
+## User Story / Functional Slice
+
+As the client-side productivity state logic, the code must persist safe records, reject malformed stored data, and avoid unsafe HTML rendering.
+
+## Dependencies
+
+- `localStorage`
+- helper logic around:
+  - storage normalization
+  - ID generation
+  - HTML escaping
+  - timestamp formatting
+
+## Happy Path Scenarios
+
+- empty state returns `{ todo: [], notes: [] }`
+- valid stored todo items survive normalization
+- valid stored note items survive normalization
+- `create` prepends new items with timestamps
+- `update` mutates target item and refreshes `updatedAt`
+- `delete` removes target item only
+- `escapeHtml` neutralizes HTML-sensitive characters
+- `formatTimestamp` returns formatted text for valid dates
+
+## Negative / Edge Scenarios
+
+- corrupted storage JSON falls back to empty state
+- todo items missing string `id` or string `text` are filtered out
+- note items missing string `id` or string `content` are filtered out
+- invalid timestamps degrade to empty string instead of throwing
+- HTML/script payloads are escaped before rendering
+
+## Accessibility / UI States
+
+- Not applicable at the pure helper/state layer
+
+## Data / Auth / Storage Notes
+
+- Key under test: `telos.productivity.v1`
+- If helper extraction happens later, these scenarios should migrate into real narrow unit specs first

--- a/tests/unit-js/README.md
+++ b/tests/unit-js/README.md
@@ -27,4 +27,8 @@ This folder captures JS unit-level scenarios that should later be automated outs
 - [timer-state.test.mjs](timer-state.test.mjs): pure timer state-machine logic, mode switching, transitions, counters, projections
 - [timer-persistence.test.mjs](timer-persistence.test.mjs): settings storage, timer serialization, reload recovery, timestamp-based hydration
 - [mini-timer.test.mjs](mini-timer.test.mjs): mini timer hydration, state mirroring, storage-driven sync, cross-page recovery
+- [productivity-tabs.test.mjs](productivity-tabs.test.mjs): productivity tab presence, active-state switching, panel visibility, no-route-change behavior
+- [productivity-interactions.test.mjs](productivity-interactions.test.mjs): todo/note create-edit-delete flows, empty states, invalid states, keyboard save behavior
+- [productivity-storage.test.mjs](productivity-storage.test.mjs): productivity storage normalization, corrupted storage fallback, cross-tab sync
+- [productivity.test-utils.mjs](productivity.test-utils.mjs): shared fake DOM/runtime harness for `productivity.js`
 - [timer-state.test-utils.mjs](timer-state.test-utils.mjs): shared isolated runtime helpers for loading `timer-state.js` without UI dependencies

--- a/tests/unit-js/README.md
+++ b/tests/unit-js/README.md
@@ -21,3 +21,9 @@ This folder captures JS unit-level scenarios that should later be automated outs
 - [01-timer-state-normalization-and-storage.md](01-timer-state-normalization-and-storage.md)
 - [02-timer-state-transitions-and-projections.md](02-timer-state-transitions-and-projections.md)
 - [03-productivity-storage-and-sanitization.md](03-productivity-storage-and-sanitization.md)
+
+## Executable Suites
+
+- [timer-state.test.mjs](timer-state.test.mjs): pure timer state-machine logic, mode switching, transitions, counters, projections
+- [timer-persistence.test.mjs](timer-persistence.test.mjs): settings storage, timer serialization, reload recovery, timestamp-based hydration
+- [timer-state.test-utils.mjs](timer-state.test-utils.mjs): shared isolated runtime helpers for loading `timer-state.js` without UI dependencies

--- a/tests/unit-js/README.md
+++ b/tests/unit-js/README.md
@@ -26,4 +26,5 @@ This folder captures JS unit-level scenarios that should later be automated outs
 
 - [timer-state.test.mjs](timer-state.test.mjs): pure timer state-machine logic, mode switching, transitions, counters, projections
 - [timer-persistence.test.mjs](timer-persistence.test.mjs): settings storage, timer serialization, reload recovery, timestamp-based hydration
+- [mini-timer.test.mjs](mini-timer.test.mjs): mini timer hydration, state mirroring, storage-driven sync, cross-page recovery
 - [timer-state.test-utils.mjs](timer-state.test-utils.mjs): shared isolated runtime helpers for loading `timer-state.js` without UI dependencies

--- a/tests/unit-js/README.md
+++ b/tests/unit-js/README.md
@@ -27,8 +27,11 @@ This folder captures JS unit-level scenarios that should later be automated outs
 - [timer-state.test.mjs](timer-state.test.mjs): pure timer state-machine logic, mode switching, transitions, counters, projections
 - [timer-persistence.test.mjs](timer-persistence.test.mjs): settings storage, timer serialization, reload recovery, timestamp-based hydration
 - [mini-timer.test.mjs](mini-timer.test.mjs): mini timer hydration, state mirroring, storage-driven sync, cross-page recovery
+- [login-validation.test.mjs](login-validation.test.mjs): login form required-field validation, disabled submit state, client-side error feedback
+- [user-profile-validation.test.mjs](user-profile-validation.test.mjs): profile page section presence, username/password frontend validation, confirm-password logic
 - [productivity-tabs.test.mjs](productivity-tabs.test.mjs): productivity tab presence, active-state switching, panel visibility, no-route-change behavior
 - [productivity-interactions.test.mjs](productivity-interactions.test.mjs): todo/note create-edit-delete flows, empty states, invalid states, keyboard save behavior
 - [productivity-storage.test.mjs](productivity-storage.test.mjs): productivity storage normalization, corrupted storage fallback, cross-tab sync
+- [dom-test-utils.mjs](dom-test-utils.mjs): shared fake DOM/runtime harness for frontend validation scripts
 - [productivity.test-utils.mjs](productivity.test-utils.mjs): shared fake DOM/runtime harness for `productivity.js`
 - [timer-state.test-utils.mjs](timer-state.test-utils.mjs): shared isolated runtime helpers for loading `timer-state.js` without UI dependencies

--- a/tests/unit-js/README.md
+++ b/tests/unit-js/README.md
@@ -1,0 +1,23 @@
+# JavaScript Unit Test Plans
+
+## Purpose
+
+This folder captures JS unit-level scenarios that should later be automated outside full browser journeys whenever narrower, faster coverage is useful.
+
+## Source Surface
+
+- [timer-state.js](../../src/main/resources/static/js/timer-state.js)
+- [productivity.js](../../src/main/resources/static/js/productivity.js)
+
+## Automation Notes
+
+- Primary automation layer: JS unit runner if introduced later
+- Priority: `P0` for `timer-state.js`
+- Priority: `P1` for isolated productivity storage/helper coverage
+- Do not block browser E2E on having this layer first; add it to stabilize pure state logic
+
+## Plans
+
+- [01-timer-state-normalization-and-storage.md](01-timer-state-normalization-and-storage.md)
+- [02-timer-state-transitions-and-projections.md](02-timer-state-transitions-and-projections.md)
+- [03-productivity-storage-and-sanitization.md](03-productivity-storage-and-sanitization.md)

--- a/tests/unit-js/README.md
+++ b/tests/unit-js/README.md
@@ -29,9 +29,15 @@ This folder captures JS unit-level scenarios that should later be automated outs
 - [mini-timer.test.mjs](mini-timer.test.mjs): mini timer hydration, state mirroring, storage-driven sync, cross-page recovery
 - [login-validation.test.mjs](login-validation.test.mjs): login form required-field validation, disabled submit state, client-side error feedback
 - [user-profile-validation.test.mjs](user-profile-validation.test.mjs): profile page section presence, username/password frontend validation, confirm-password logic
+- [settings-validation.test.mjs](settings-validation.test.mjs): timer settings numeric/type/range validation, error messages, correction flow, invalid-save blocking
 - [productivity-tabs.test.mjs](productivity-tabs.test.mjs): productivity tab presence, active-state switching, panel visibility, no-route-change behavior
-- [productivity-interactions.test.mjs](productivity-interactions.test.mjs): todo/note create-edit-delete flows, empty states, invalid states, keyboard save behavior
+- [productivity-interactions.test.mjs](productivity-interactions.test.mjs): todo/note create-edit-delete flows, empty states, invalid states, keyboard save behavior, anti-67 guardrails
 - [productivity-storage.test.mjs](productivity-storage.test.mjs): productivity storage normalization, corrupted storage fallback, cross-tab sync
 - [dom-test-utils.mjs](dom-test-utils.mjs): shared fake DOM/runtime harness for frontend validation scripts
 - [productivity.test-utils.mjs](productivity.test-utils.mjs): shared fake DOM/runtime harness for `productivity.js`
 - [timer-state.test-utils.mjs](timer-state.test-utils.mjs): shared isolated runtime helpers for loading `timer-state.js` without UI dependencies
+
+## Negative-Test Notes
+
+- JS negative tests use inline labels like `[ui-negative]`.
+- See [NegativeTestLanes.md](../NegativeTestLanes.md) for the current lane split and run commands.

--- a/tests/unit-js/dom-test-utils.mjs
+++ b/tests/unit-js/dom-test-utils.mjs
@@ -1,0 +1,277 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+function toDatasetKey(attribute) {
+    return attribute.replace(/^data-/, "").replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+function createEventTarget() {
+    const listeners = new Map();
+
+    return {
+        addEventListener(type, callback) {
+            if (!listeners.has(type)) {
+                listeners.set(type, []);
+            }
+            listeners.get(type).push(callback);
+        },
+        dispatchEvent(event) {
+            const safeEvent = event;
+            safeEvent.target ??= this;
+            safeEvent.currentTarget = this;
+            safeEvent.defaultPrevented = false;
+            safeEvent.preventDefault ??= () => {
+                safeEvent.defaultPrevented = true;
+            };
+            safeEvent.stopPropagation ??= () => {};
+
+            const callbacks = listeners.get(safeEvent.type) || [];
+            callbacks.forEach(callback => callback(safeEvent));
+            return !safeEvent.defaultPrevented;
+        }
+    };
+}
+
+function createClassList(initialClasses = []) {
+    const classes = new Set(initialClasses);
+
+    return {
+        add(...tokens) {
+            tokens.forEach(token => classes.add(token));
+        },
+        remove(...tokens) {
+            tokens.forEach(token => classes.delete(token));
+        },
+        toggle(token, force) {
+            if (typeof force === "boolean") {
+                if (force) {
+                    classes.add(token);
+                    return true;
+                }
+
+                classes.delete(token);
+                return false;
+            }
+
+            if (classes.has(token)) {
+                classes.delete(token);
+                return false;
+            }
+
+            classes.add(token);
+            return true;
+        },
+        contains(token) {
+            return classes.has(token);
+        }
+    };
+}
+
+export function createElement({
+    tagName = "div",
+    id = "",
+    name = "",
+    dataset = {},
+    attributes = {},
+    classNames = [],
+    value = "",
+    content = "",
+    disabled = false
+} = {}) {
+    const elementTarget = createEventTarget();
+    const attributeMap = new Map(Object.entries(attributes));
+
+    const element = {
+        ...elementTarget,
+        tagName: tagName.toUpperCase(),
+        id,
+        name,
+        dataset: { ...dataset },
+        classList: createClassList(classNames),
+        children: [],
+        parentNode: null,
+        textContent: content,
+        value,
+        disabled,
+        style: {},
+        tabIndex: 0,
+        appendChild(child) {
+            child.parentNode = this;
+            this.children.push(child);
+            return child;
+        },
+        querySelector(selector) {
+            return queryWithin(this, selector, true);
+        },
+        querySelectorAll(selector) {
+            return queryWithin(this, selector, false);
+        },
+        setAttribute(key, nextValue) {
+            const safeValue = String(nextValue);
+            attributeMap.set(key, safeValue);
+            if (key === "id") this.id = safeValue;
+            if (key === "name") this.name = safeValue;
+            if (key === "content") this.content = safeValue;
+            if (key.startsWith("data-")) {
+                this.dataset[toDatasetKey(key)] = safeValue;
+            }
+        },
+        getAttribute(key) {
+            if (key.startsWith("data-")) {
+                const value = this.dataset[toDatasetKey(key)];
+                return typeof value === "string" ? value : null;
+            }
+            if (key === "name" && this.name) return this.name;
+            return attributeMap.has(key) ? attributeMap.get(key) : null;
+        },
+        removeAttribute(key) {
+            attributeMap.delete(key);
+            if (key.startsWith("data-")) {
+                delete this.dataset[toDatasetKey(key)];
+            }
+        },
+        focus() {
+            this.wasFocused = true;
+        },
+        closest(selector) {
+            let current = this;
+            while (current) {
+                if (matchesSelector(current, selector)) {
+                    return current;
+                }
+                current = current.parentNode;
+            }
+            return null;
+        },
+        contains(candidate) {
+            let current = candidate;
+            while (current) {
+                if (current === this) return true;
+                current = current.parentNode;
+            }
+            return false;
+        },
+        reset() {
+            getDescendants(this).forEach(descendant => {
+                if (descendant.tagName === "INPUT" || descendant.tagName === "TEXTAREA") {
+                    descendant.value = "";
+                }
+            });
+        }
+    };
+
+    return element;
+}
+
+function getDescendants(node) {
+    const descendants = [];
+    node.children.forEach(child => {
+        descendants.push(child, ...getDescendants(child));
+    });
+    return descendants;
+}
+
+function matchesSelector(element, selector) {
+    const trimmed = selector.trim();
+    if (!trimmed) return false;
+
+    if (trimmed.includes(",")) {
+        return trimmed.split(",").some(part => matchesSelector(element, part));
+    }
+
+    if (trimmed.startsWith("#")) {
+        return element.id === trimmed.slice(1);
+    }
+
+    if (trimmed.startsWith(".")) {
+        return element.classList.contains(trimmed.slice(1));
+    }
+
+    const attrMatch = trimmed.match(/^(?:([a-zA-Z]+))?\[([^=\]]+)(?:="([^"]*)")?\]$/);
+    if (attrMatch) {
+        const [, tagName, rawAttribute, expectedValue] = attrMatch;
+        if (tagName && element.tagName !== tagName.toUpperCase()) {
+            return false;
+        }
+
+        let actualValue = null;
+        if (rawAttribute.startsWith("data-")) {
+            actualValue = element.dataset[toDatasetKey(rawAttribute)];
+        } else if (rawAttribute === "name") {
+            actualValue = element.name;
+        } else if (rawAttribute === "content") {
+            actualValue = element.content;
+        } else {
+            actualValue = element.getAttribute(rawAttribute);
+        }
+
+        if (typeof expectedValue === "undefined") {
+            return actualValue !== null && typeof actualValue !== "undefined";
+        }
+
+        return actualValue === expectedValue;
+    }
+
+    return element.tagName === trimmed.toUpperCase();
+}
+
+function queryWithin(root, selector, firstOnly) {
+    const trimmed = selector.trim();
+    if (!trimmed) {
+        return firstOnly ? null : [];
+    }
+
+    if (trimmed.includes(",")) {
+        const results = [];
+        trimmed.split(",").map(part => part.trim()).forEach(part => {
+            queryWithin(root, part, false).forEach(element => {
+                if (!results.includes(element)) {
+                    results.push(element);
+                }
+            });
+        });
+        return firstOnly ? (results[0] || null) : results;
+    }
+
+    const descendantMatch = trimmed.match(/^(.+)\s+(.+)$/);
+    if (descendantMatch) {
+        const [, ancestorSelector, childSelector] = descendantMatch;
+        const results = [];
+        queryWithin(root, ancestorSelector, false).forEach(ancestor => {
+            queryWithin(ancestor, childSelector, false).forEach(element => {
+                if (!results.includes(element)) {
+                    results.push(element);
+                }
+            });
+        });
+        return firstOnly ? (results[0] || null) : results;
+    }
+
+    const matches = getDescendants(root).filter(element => matchesSelector(element, trimmed));
+    return firstOnly ? (matches[0] || null) : matches;
+}
+
+export function createDocument(roots) {
+    const documentTarget = createEventTarget();
+    const rootNode = { children: roots };
+
+    return {
+        ...documentTarget,
+        getElementById(id) {
+            return roots.find(root => root.id === id) || null;
+        },
+        querySelector(selector) {
+            return queryWithin(rootNode, selector, true);
+        },
+        querySelectorAll(selector) {
+            return queryWithin(rootNode, selector, false);
+        }
+    };
+}
+
+export function runBrowserScript(scriptPath, context) {
+    const source = readFileSync(path.resolve(scriptPath), "utf8");
+    vm.createContext(context);
+    vm.runInContext(source, context, { filename: path.basename(scriptPath) });
+}

--- a/tests/unit-js/login-validation.test.mjs
+++ b/tests/unit-js/login-validation.test.mjs
@@ -136,3 +136,47 @@ test("valid login input clears error state and passes frontend validation withou
     assert.equal(runtime.identifierError.classList.contains("hidden"), true);
     assert.equal(runtime.passwordError.classList.contains("hidden"), true);
 });
+
+test("[ui-negative] whitespace-only login input stays disabled and shows required-field errors on submit", () => {
+    const runtime = bootstrapLoginPage();
+
+    runtime.identifierInput.value = "   ";
+    runtime.passwordInput.value = "   ";
+    runtime.identifierInput.dispatchEvent({ type: "input", target: runtime.identifierInput });
+    runtime.passwordInput.dispatchEvent({ type: "input", target: runtime.passwordInput });
+
+    assert.equal(runtime.submitButton.disabled, true);
+
+    const submitEvent = {
+        type: "submit",
+        target: runtime.form
+    };
+    runtime.form.dispatchEvent(submitEvent);
+
+    assert.equal(submitEvent.defaultPrevented, true);
+    assert.equal(runtime.identifierError.textContent, "Email or username is required");
+    assert.equal(runtime.passwordError.textContent, "Password is required");
+});
+
+test("[ui-negative] forbidden 67-style login identifiers are blocked client-side with a visible message", () => {
+    const runtime = bootstrapLoginPage();
+
+    runtime.identifierInput.value = " Six   Seven ";
+    runtime.passwordInput.value = "valid-password";
+    runtime.identifierInput.dispatchEvent({ type: "input", target: runtime.identifierInput });
+    runtime.passwordInput.dispatchEvent({ type: "input", target: runtime.passwordInput });
+
+    assert.equal(runtime.submitButton.disabled, true);
+    assert.equal(runtime.identifierError.classList.contains("hidden"), false);
+    assert.equal(runtime.identifierError.textContent, "67 and six seven are not allowed here.");
+
+    const submitEvent = {
+        type: "submit",
+        target: runtime.form
+    };
+    runtime.form.dispatchEvent(submitEvent);
+
+    assert.equal(submitEvent.defaultPrevented, true);
+    assert.equal(runtime.formMessage.classList.contains("hidden"), false);
+    assert.equal(runtime.formMessage.textContent, "67 and six seven are not allowed here.");
+});

--- a/tests/unit-js/login-validation.test.mjs
+++ b/tests/unit-js/login-validation.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    createDocument,
+    createElement,
+    runBrowserScript
+} from "./dom-test-utils.mjs";
+
+function bootstrapLoginPage() {
+    const form = createElement({
+        tagName: "form",
+        id: "loginForm",
+        dataset: { authForm: "login" }
+    });
+    const identifierInput = createElement({
+        tagName: "input",
+        id: "loginIdentifier",
+        name: "username",
+        classNames: ["settings-input", "auth-input"]
+    });
+    const identifierError = createElement({
+        tagName: "p",
+        dataset: { errorFor: "loginIdentifier" },
+        classNames: ["form-field-error", "hidden"]
+    });
+    const passwordInput = createElement({
+        tagName: "input",
+        id: "loginPassword",
+        name: "password",
+        classNames: ["settings-input", "auth-input"]
+    });
+    const passwordError = createElement({
+        tagName: "p",
+        dataset: { errorFor: "loginPassword" },
+        classNames: ["form-field-error", "hidden"]
+    });
+    const formMessage = createElement({
+        tagName: "p",
+        dataset: { formMessage: "" },
+        classNames: ["form-message", "hidden"]
+    });
+    const submitButton = createElement({
+        tagName: "button",
+        classNames: ["btn", "btn--primary", "auth-submit"]
+    });
+
+    form.appendChild(identifierInput);
+    form.appendChild(identifierError);
+    form.appendChild(passwordInput);
+    form.appendChild(passwordError);
+    form.appendChild(formMessage);
+    form.appendChild(submitButton);
+
+    const document = createDocument([form]);
+    const context = {
+        document,
+        window: null,
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        }
+    };
+    context.window = context;
+
+    runBrowserScript("src/main/resources/static/js/login-validation.js", context);
+    document.dispatchEvent({ type: "DOMContentLoaded", target: document });
+
+    return {
+        form,
+        identifierInput,
+        identifierError,
+        passwordInput,
+        passwordError,
+        formMessage,
+        submitButton
+    };
+}
+
+test("login page renders the expected form structure and keeps submit disabled until fields are filled", () => {
+    const runtime = bootstrapLoginPage();
+
+    assert.ok(runtime.form);
+    assert.ok(runtime.identifierInput);
+    assert.ok(runtime.passwordInput);
+    assert.ok(runtime.submitButton);
+    assert.equal(runtime.submitButton.disabled, true);
+    assert.equal(runtime.submitButton.getAttribute("aria-disabled"), "true");
+
+    runtime.identifierInput.value = "demo-user";
+    runtime.identifierInput.dispatchEvent({ type: "input", target: runtime.identifierInput });
+    assert.equal(runtime.submitButton.disabled, true);
+
+    runtime.passwordInput.value = "secret123";
+    runtime.passwordInput.dispatchEvent({ type: "input", target: runtime.passwordInput });
+    assert.equal(runtime.submitButton.disabled, false);
+    assert.equal(runtime.submitButton.getAttribute("aria-disabled"), "false");
+});
+
+test("login validation blocks empty submit and shows field-level error state", () => {
+    const runtime = bootstrapLoginPage();
+
+    const submitEvent = {
+        type: "submit",
+        target: runtime.form
+    };
+    runtime.form.dispatchEvent(submitEvent);
+
+    assert.equal(submitEvent.defaultPrevented, true);
+    assert.equal(runtime.identifierInput.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.passwordInput.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.identifierError.classList.contains("hidden"), false);
+    assert.equal(runtime.passwordError.classList.contains("hidden"), false);
+    assert.equal(runtime.formMessage.classList.contains("hidden"), false);
+    assert.ok(runtime.formMessage.textContent.includes("Fill in both required fields"));
+});
+
+test("valid login input clears error state and passes frontend validation without auth integration", () => {
+    const runtime = bootstrapLoginPage();
+
+    runtime.identifierInput.value = "user@test.com";
+    runtime.passwordInput.value = "valid-password";
+    runtime.identifierInput.dispatchEvent({ type: "input", target: runtime.identifierInput });
+    runtime.passwordInput.dispatchEvent({ type: "input", target: runtime.passwordInput });
+
+    const submitEvent = {
+        type: "submit",
+        target: runtime.form
+    };
+    runtime.form.dispatchEvent(submitEvent);
+
+    assert.equal(submitEvent.defaultPrevented, false);
+    assert.equal(runtime.identifierInput.getAttribute("aria-invalid"), null);
+    assert.equal(runtime.passwordInput.getAttribute("aria-invalid"), null);
+    assert.equal(runtime.identifierError.classList.contains("hidden"), true);
+    assert.equal(runtime.passwordError.classList.contains("hidden"), true);
+});

--- a/tests/unit-js/mini-timer.test.mjs
+++ b/tests/unit-js/mini-timer.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+
+import {
+    createLocalStorage,
+    withMockedNow
+} from "./timer-state.test-utils.mjs";
+
+function createEventTarget() {
+    const listeners = new Map();
+
+    return {
+        addEventListener(type, callback) {
+            if (!listeners.has(type)) {
+                listeners.set(type, []);
+            }
+
+            listeners.get(type).push(callback);
+        },
+        dispatchEvent(event) {
+            const callbacks = listeners.get(event.type) || [];
+
+            callbacks.forEach(callback => callback(event));
+            return true;
+        }
+    };
+}
+
+function createClassList(initialClasses = []) {
+    const classes = new Set(initialClasses);
+
+    return {
+        add(...tokens) {
+            tokens.forEach(token => classes.add(token));
+        },
+        remove(...tokens) {
+            tokens.forEach(token => classes.delete(token));
+        },
+        contains(token) {
+            return classes.has(token);
+        }
+    };
+}
+
+function createElement(id, initialClasses = []) {
+    return {
+        id,
+        dataset: {},
+        textContent: "",
+        classList: createClassList(initialClasses)
+    };
+}
+
+function createDocument(elements) {
+    const documentTarget = createEventTarget();
+    const elementMap = new Map(elements.map(element => [element.id, element]));
+
+    return {
+        ...documentTarget,
+        getElementById(id) {
+            return elementMap.get(id) || null;
+        }
+    };
+}
+
+class FakeCustomEvent {
+    constructor(type, init = {}) {
+        this.type = type;
+        this.detail = init.detail;
+    }
+}
+
+function runScriptInContext(context, relativePath) {
+    const filePath = path.resolve(relativePath);
+    const source = readFileSync(filePath, "utf8");
+
+    vm.runInContext(source, context, { filename: path.basename(filePath) });
+}
+
+function bootstrapMiniTimer({ initialStorage = {}, now = 1_000_000 } = {}) {
+    const localStorage = createLocalStorage(initialStorage);
+    const elements = {
+        miniTimer: createElement("miniTimer", ["mini-timer", "mini-timer--pomodoro"]),
+        miniTimerMode: createElement("miniTimerMode"),
+        miniTimerTime: createElement("miniTimerTime"),
+        miniTimerStatus: createElement("miniTimerStatus")
+    };
+    const document = createDocument(Object.values(elements));
+    const windowTarget = createEventTarget();
+    const intervals = new Map();
+    let intervalId = 0;
+
+    const context = {
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        },
+        document,
+        localStorage,
+        Date,
+        Math,
+        JSON,
+        Number,
+        String,
+        Boolean,
+        Object,
+        Array,
+        Intl,
+        CustomEvent: FakeCustomEvent,
+        setInterval(callback, delay) {
+            intervalId += 1;
+            intervals.set(intervalId, { callback, delay });
+            return intervalId;
+        },
+        clearInterval(id) {
+            intervals.delete(id);
+        },
+        addEventListener(...args) {
+            return windowTarget.addEventListener(...args);
+        },
+        dispatchEvent(...args) {
+            return windowTarget.dispatchEvent(...args);
+        }
+    };
+
+    context.window = context;
+
+    vm.createContext(context);
+
+    return withMockedNow(now, () => {
+        runScriptInContext(context, "src/main/resources/static/js/timer-state.js");
+        runScriptInContext(context, "src/main/resources/static/js/mini-timer.js");
+        document.dispatchEvent(new FakeCustomEvent("DOMContentLoaded"));
+
+        return {
+            document,
+            window: context,
+            localStorage,
+            elements,
+            intervals,
+            timerState: context.PomodoroTimerState
+        };
+    });
+}
+
+function createRunningState(timerState, settings, startAt, elapsedSeconds = 0) {
+    const freshState = timerState.getDefaultTimerState(settings);
+    const started = timerState.startTimerState(freshState, settings, startAt);
+
+    return {
+        ...started,
+        remainingSeconds: Math.max(0, started.remainingSeconds - elapsedSeconds)
+    };
+}
+
+test("mini timer hydrates from persisted running timer state and shows matching mode, time, and running status", () => {
+    const runtime = withMockedNow(2_015_000, () => {
+        const setupContext = bootstrapMiniTimer({ now: 2_000_000 });
+        const settings = setupContext.timerState.getDefaultSettings();
+        const runningState = createRunningState(setupContext.timerState, settings, 2_000_000, 0);
+
+        setupContext.timerState.saveSettings(settings);
+        setupContext.timerState.saveTimerState(runningState, settings);
+
+        return bootstrapMiniTimer({
+            initialStorage: setupContext.localStorage.snapshot(),
+            now: 2_015_000
+        });
+    });
+
+    assert.equal(runtime.elements.miniTimerMode.textContent, "Pomodoro");
+    assert.equal(runtime.elements.miniTimerTime.textContent, "24:45");
+    assert.equal(runtime.elements.miniTimerStatus.textContent, "Running");
+    assert.equal(runtime.elements.miniTimer.dataset.running, "true");
+    assert.equal(runtime.elements.miniTimer.classList.contains("mini-timer--pomodoro"), true);
+});
+
+test("mini timer updates immediately when the main timer dispatches timer state changes", () => {
+    const runtime = bootstrapMiniTimer();
+    const settings = runtime.timerState.getDefaultSettings();
+    const pausedState = {
+        currentMode: "short-break",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 150,
+        completedPomodorosInCycle: 1,
+        completedFocusCycles: 0
+    };
+
+    runtime.document.dispatchEvent(new FakeCustomEvent("timer:state-updated", {
+        detail: {
+            settings,
+            state: pausedState
+        }
+    }));
+
+    assert.equal(runtime.elements.miniTimerMode.textContent, "Short Break");
+    assert.equal(runtime.elements.miniTimerTime.textContent, "02:30");
+    assert.equal(runtime.elements.miniTimerStatus.textContent, "Paused");
+    assert.equal(runtime.elements.miniTimer.dataset.running, "false");
+    assert.equal(runtime.elements.miniTimer.classList.contains("mini-timer--short-break"), true);
+});
+
+test("mini timer reacts to storage-driven timer changes without manual reload", () => {
+    const runtime = bootstrapMiniTimer();
+    const settings = runtime.timerState.getDefaultSettings();
+    const updatedState = {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 754,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 0
+    };
+
+    runtime.timerState.saveSettings(settings);
+    runtime.timerState.saveTimerState(updatedState, settings);
+    runtime.window.dispatchEvent({
+        type: "storage",
+        key: runtime.timerState.keys.TIMER_STATE_KEY
+    });
+
+    assert.equal(runtime.elements.miniTimerMode.textContent, "Pomodoro");
+    assert.equal(runtime.elements.miniTimerTime.textContent, "12:34");
+    assert.equal(runtime.elements.miniTimerStatus.textContent, "Paused");
+    assert.equal(runtime.elements.miniTimer.dataset.running, "false");
+});
+
+test("mini timer keeps the current state when a new page bootstraps from the same storage", () => {
+    const initialRuntime = withMockedNow(5_000_000, () => bootstrapMiniTimer({ now: 5_000_000 }));
+    const settings = initialRuntime.timerState.getDefaultSettings();
+    const runningState = createRunningState(initialRuntime.timerState, settings, 5_000_000, 0);
+
+    initialRuntime.timerState.saveSettings(settings);
+    initialRuntime.timerState.saveTimerState(runningState, settings);
+
+    const nextPageRuntime = withMockedNow(5_020_000, () => bootstrapMiniTimer({
+        initialStorage: initialRuntime.localStorage.snapshot(),
+        now: 5_020_000
+    }));
+
+    assert.equal(nextPageRuntime.elements.miniTimerMode.textContent, "Pomodoro");
+    assert.equal(nextPageRuntime.elements.miniTimerTime.textContent, "24:40");
+    assert.equal(nextPageRuntime.elements.miniTimerStatus.textContent, "Running");
+    assert.equal(nextPageRuntime.elements.miniTimer.dataset.running, "true");
+});

--- a/tests/unit-js/productivity-interactions.test.mjs
+++ b/tests/unit-js/productivity-interactions.test.mjs
@@ -128,3 +128,48 @@ test("blank note submission marks the field invalid and shows an error message",
     assert.equal(runtime.messages.notes.classList.contains("hidden"), false);
     assert.ok(runtime.messages.notes.textContent.includes("Please enter a note"));
 });
+
+test("[ui-negative] forbidden 67-style todo and note content is rejected without changing storage", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.inputs.todo.value = "67";
+    submitForm(runtime, "todo");
+    let stored = getStoredProductivityState(runtime);
+    assert.equal(stored, null);
+    assert.equal(runtime.messages.todo.textContent, "67 and six seven are not allowed here.");
+    assert.equal(runtime.inputs.todo.getAttribute("aria-invalid"), "true");
+
+    runtime.tabs.notes.dispatchEvent({
+        type: "click",
+        target: runtime.tabs.notes
+    });
+    runtime.inputs.notes.value = "Six seven";
+    submitForm(runtime, "notes");
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored, null);
+    assert.equal(runtime.messages.notes.textContent, "67 and six seven are not allowed here.");
+    assert.equal(runtime.inputs.notes.getAttribute("aria-invalid"), "true");
+});
+
+test("[ui-negative] invalid edit-save keeps the previous productivity item unchanged and shows feedback", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.inputs.todo.value = "Ship docs";
+    submitForm(runtime, "todo");
+    let stored = getStoredProductivityState(runtime);
+    const itemId = stored.todo[0].id;
+
+    clickListAction(runtime, "todo", itemId, "edit");
+    const todoEditor = runtime.lists.todo.querySelector(`[data-item-id="${itemId}"] [data-edit-field="todo"]`);
+    todoEditor.value = "   ";
+    clickListAction(runtime, "todo", itemId, "save-edit");
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo[0].text, "Ship docs");
+    assert.equal(runtime.messages.todo.textContent, "Please enter a task before saving it.");
+
+    todoEditor.value = "six seven";
+    clickListAction(runtime, "todo", itemId, "save-edit");
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo[0].text, "Ship docs");
+    assert.equal(runtime.messages.todo.textContent, "67 and six seven are not allowed here.");
+});

--- a/tests/unit-js/productivity-interactions.test.mjs
+++ b/tests/unit-js/productivity-interactions.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    bootstrapProductivityRuntime,
+    clickListAction,
+    getStoredProductivityState,
+    inputValue,
+    submitForm,
+    toggleTodo,
+    triggerEditorKey
+} from "./productivity.test-utils.mjs";
+
+test("todo and notes empty states are visible on a fresh productivity page", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    assert.equal(runtime.emptyStates.todo.classList.contains("hidden"), false);
+    assert.equal(runtime.emptyStates.notes.classList.contains("hidden"), false);
+});
+
+test("adding a valid todo item stores it, hides the empty state, and resets the form", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.inputs.todo.value = "Ship release checklist";
+    submitForm(runtime, "todo");
+
+    const stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo.length, 1);
+    assert.equal(stored.todo[0].text, "Ship release checklist");
+    assert.equal(stored.todo[0].completed, false);
+    assert.equal(runtime.emptyStates.todo.classList.contains("hidden"), true);
+    assert.equal(runtime.inputs.todo.value, "");
+    assert.ok(runtime.lists.todo.innerHTML.includes("Ship release checklist"));
+});
+
+test("blank todo submission marks the field invalid and shows an error message", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.inputs.todo.value = "   ";
+    submitForm(runtime, "todo");
+
+    assert.equal(runtime.inputs.todo.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.messages.todo.classList.contains("hidden"), false);
+    assert.ok(runtime.messages.todo.textContent.includes("Please enter a task"));
+
+    inputValue(runtime, "todo", "Fix docs");
+    assert.equal(runtime.inputs.todo.getAttribute("aria-invalid"), null);
+    assert.equal(runtime.messages.todo.classList.contains("hidden"), true);
+});
+
+test("todo item supports complete, edit, save, cancel, delete, and keyboard save", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.inputs.todo.value = "Review pull request";
+    submitForm(runtime, "todo");
+    let stored = getStoredProductivityState(runtime);
+    const itemId = stored.todo[0].id;
+
+    toggleTodo(runtime, itemId, true);
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo[0].completed, true);
+
+    clickListAction(runtime, "todo", itemId, "edit");
+    const todoEditor = runtime.lists.todo.querySelector(`[data-item-id="${itemId}"] [data-edit-field="todo"]`);
+    assert.ok(todoEditor);
+    assert.equal(todoEditor.wasFocused, true);
+
+    todoEditor.value = "Review final pull request";
+    triggerEditorKey(runtime, "todo", itemId, { key: "Enter" });
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo[0].text, "Review final pull request");
+
+    clickListAction(runtime, "todo", itemId, "edit");
+    const secondEditor = runtime.lists.todo.querySelector(`[data-item-id="${itemId}"] [data-edit-field="todo"]`);
+    secondEditor.value = "Temporary edit";
+    clickListAction(runtime, "todo", itemId, "cancel-edit");
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo[0].text, "Review final pull request");
+
+    clickListAction(runtime, "todo", itemId, "delete");
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.todo.length, 0);
+    assert.equal(runtime.emptyStates.todo.classList.contains("hidden"), false);
+});
+
+test("adding and editing notes preserves content, supports keyboard save modifiers, and escapes HTML", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.tabs.notes.dispatchEvent({
+        type: "click",
+        target: runtime.tabs.notes
+    });
+    runtime.inputs.notes.value = "Line one\n<script>alert(1)</script>";
+    submitForm(runtime, "notes");
+
+    let stored = getStoredProductivityState(runtime);
+    const itemId = stored.notes[0].id;
+    assert.equal(stored.notes.length, 1);
+    assert.equal(runtime.emptyStates.notes.classList.contains("hidden"), true);
+    assert.ok(runtime.lists.notes.innerHTML.includes("Line one<br>&lt;script&gt;alert(1)&lt;/script&gt;"));
+
+    clickListAction(runtime, "notes", itemId, "edit");
+    const noteEditor = runtime.lists.notes.querySelector(`[data-item-id="${itemId}"] [data-edit-field="notes"]`);
+    assert.ok(noteEditor);
+
+    noteEditor.value = "Updated note";
+    triggerEditorKey(runtime, "notes", itemId, { key: "Enter" });
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.notes[0].content, "Line one\n<script>alert(1)</script>");
+
+    triggerEditorKey(runtime, "notes", itemId, { key: "Enter", ctrlKey: true });
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.notes[0].content, "Updated note");
+
+    clickListAction(runtime, "notes", itemId, "delete");
+    stored = getStoredProductivityState(runtime);
+    assert.equal(stored.notes.length, 0);
+    assert.equal(runtime.emptyStates.notes.classList.contains("hidden"), false);
+});
+
+test("blank note submission marks the field invalid and shows an error message", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.inputs.notes.value = "\n  ";
+    submitForm(runtime, "notes");
+
+    assert.equal(runtime.inputs.notes.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.messages.notes.classList.contains("hidden"), false);
+    assert.ok(runtime.messages.notes.textContent.includes("Please enter a note"));
+});

--- a/tests/unit-js/productivity-storage.test.mjs
+++ b/tests/unit-js/productivity-storage.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createLocalStorage } from "./timer-state.test-utils.mjs";
+import {
+    bootstrapProductivityRuntime,
+    dispatchStorageSync,
+    getStoredProductivityState,
+    submitForm
+} from "./productivity.test-utils.mjs";
+
+test("productivity page normalizes valid stored data and ignores malformed entries", () => {
+    const localStorage = createLocalStorage({
+        "telos.productivity.v1": JSON.stringify({
+            todo: [
+                {
+                    id: "todo-1",
+                    text: "Persisted task",
+                    completed: true,
+                    createdAt: "2026-04-08T10:00:00.000Z",
+                    updatedAt: "2026-04-08T10:05:00.000Z"
+                },
+                {
+                    id: 42,
+                    text: "bad item"
+                }
+            ],
+            notes: [
+                {
+                    id: "note-1",
+                    content: "Persisted note",
+                    createdAt: "bad-date",
+                    updatedAt: "2026-04-08T10:07:00.000Z"
+                },
+                {
+                    content: "missing id"
+                }
+            ]
+        })
+    });
+
+    const runtime = bootstrapProductivityRuntime({ localStorage });
+
+    assert.ok(runtime.lists.todo.innerHTML.includes("Persisted task"));
+    assert.ok(!runtime.lists.todo.innerHTML.includes("bad item"));
+    assert.ok(runtime.lists.notes.innerHTML.includes("Persisted note"));
+    assert.equal(runtime.emptyStates.todo.classList.contains("hidden"), true);
+    assert.equal(runtime.emptyStates.notes.classList.contains("hidden"), true);
+});
+
+test("corrupted productivity storage falls back to a safe empty state", () => {
+    const localStorage = createLocalStorage({
+        "telos.productivity.v1": "{broken-json"
+    });
+
+    const runtime = bootstrapProductivityRuntime({ localStorage });
+
+    assert.equal(runtime.emptyStates.todo.classList.contains("hidden"), false);
+    assert.equal(runtime.emptyStates.notes.classList.contains("hidden"), false);
+    assert.equal(runtime.lists.todo.innerHTML, "");
+    assert.equal(runtime.lists.notes.innerHTML, "");
+});
+
+test("storage event sync updates another productivity page instance without reload", () => {
+    const sharedStorage = createLocalStorage();
+    const firstRuntime = bootstrapProductivityRuntime({ localStorage: sharedStorage });
+    const secondRuntime = bootstrapProductivityRuntime({ localStorage: sharedStorage });
+
+    firstRuntime.inputs.todo.value = "Cross-tab task";
+    submitForm(firstRuntime, "todo");
+
+    dispatchStorageSync(secondRuntime);
+
+    const stored = getStoredProductivityState(secondRuntime);
+    assert.equal(stored.todo.length, 1);
+    assert.equal(stored.todo[0].text, "Cross-tab task");
+    assert.ok(secondRuntime.lists.todo.innerHTML.includes("Cross-tab task"));
+    assert.equal(secondRuntime.emptyStates.todo.classList.contains("hidden"), true);
+});

--- a/tests/unit-js/productivity-tabs.test.mjs
+++ b/tests/unit-js/productivity-tabs.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { bootstrapProductivityRuntime } from "./productivity.test-utils.mjs";
+
+test("productivity page renders the available tabs and keeps todo active by default", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    assert.ok(runtime.tabs.todo);
+    assert.ok(runtime.tabs.notes);
+
+    assert.equal(runtime.tabs.todo.classList.contains("productivity-tab--active"), true);
+    assert.equal(runtime.tabs.todo.getAttribute("aria-selected"), "true");
+    assert.equal(runtime.tabs.notes.classList.contains("productivity-tab--active"), false);
+    assert.equal(runtime.tabs.notes.getAttribute("aria-selected"), "false");
+
+    assert.equal(runtime.panels.todo.classList.contains("hidden"), false);
+    assert.equal(runtime.panels.todo.getAttribute("aria-hidden"), "false");
+    assert.equal(runtime.panels.notes.classList.contains("hidden"), true);
+    assert.equal(runtime.panels.notes.getAttribute("aria-hidden"), "true");
+});
+
+test("switching tabs updates active state and shows the matching panel without route navigation", () => {
+    const runtime = bootstrapProductivityRuntime();
+    const originalPath = runtime.window.location.pathname;
+
+    runtime.tabs.notes.dispatchEvent({
+        type: "click",
+        target: runtime.tabs.notes
+    });
+
+    assert.equal(runtime.window.location.pathname, originalPath);
+    assert.equal(runtime.tabs.notes.classList.contains("productivity-tab--active"), true);
+    assert.equal(runtime.tabs.notes.getAttribute("aria-selected"), "true");
+    assert.equal(runtime.tabs.notes.tabIndex, 0);
+    assert.equal(runtime.tabs.todo.classList.contains("productivity-tab--active"), false);
+    assert.equal(runtime.tabs.todo.getAttribute("aria-selected"), "false");
+    assert.equal(runtime.tabs.todo.tabIndex, -1);
+
+    assert.equal(runtime.panels.notes.classList.contains("hidden"), false);
+    assert.equal(runtime.panels.notes.getAttribute("aria-hidden"), "false");
+    assert.equal(runtime.panels.todo.classList.contains("hidden"), true);
+    assert.equal(runtime.panels.todo.getAttribute("aria-hidden"), "true");
+});
+
+test("switching back to todo restores the original active state and keeps the page shell intact", () => {
+    const runtime = bootstrapProductivityRuntime();
+
+    runtime.tabs.notes.dispatchEvent({
+        type: "click",
+        target: runtime.tabs.notes
+    });
+    runtime.tabs.todo.dispatchEvent({
+        type: "click",
+        target: runtime.tabs.todo
+    });
+
+    assert.equal(runtime.tabs.todo.classList.contains("productivity-tab--active"), true);
+    assert.equal(runtime.tabs.notes.classList.contains("productivity-tab--active"), false);
+    assert.equal(runtime.panels.todo.classList.contains("hidden"), false);
+    assert.equal(runtime.panels.notes.classList.contains("hidden"), true);
+    assert.equal(runtime.tabs.todo.getAttribute("aria-controls"), "productivity-panel-todo");
+    assert.equal(runtime.tabs.notes.getAttribute("aria-controls"), "productivity-panel-notes");
+});

--- a/tests/unit-js/productivity.test-utils.mjs
+++ b/tests/unit-js/productivity.test-utils.mjs
@@ -1,0 +1,599 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+import { createLocalStorage } from "./timer-state.test-utils.mjs";
+
+function toDatasetKey(attribute) {
+    return attribute.replace(/^data-/, "").replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+function decodeHtml(value) {
+    return String(value)
+        .replaceAll("&quot;", "\"")
+        .replaceAll("&#39;", "'")
+        .replaceAll("&gt;", ">")
+        .replaceAll("&lt;", "<")
+        .replaceAll("&amp;", "&");
+}
+
+function createEventTarget() {
+    const listeners = new Map();
+
+    return {
+        addEventListener(type, callback) {
+            if (!listeners.has(type)) {
+                listeners.set(type, []);
+            }
+
+            listeners.get(type).push(callback);
+        },
+        dispatchEvent(event) {
+            const safeEvent = event;
+            safeEvent.defaultPrevented = false;
+            safeEvent.preventDefault ??= () => {
+                safeEvent.defaultPrevented = true;
+            };
+            safeEvent.stopPropagation ??= () => {};
+            safeEvent.currentTarget = this;
+
+            const callbacks = listeners.get(event.type) || [];
+            callbacks.forEach(callback => callback(safeEvent));
+            return !safeEvent.defaultPrevented;
+        }
+    };
+}
+
+function createClassList(initialClasses = []) {
+    const classes = new Set(initialClasses);
+
+    return {
+        add(...tokens) {
+            tokens.forEach(token => classes.add(token));
+        },
+        remove(...tokens) {
+            tokens.forEach(token => classes.delete(token));
+        },
+        toggle(token, force) {
+            if (typeof force === "boolean") {
+                if (force) {
+                    classes.add(token);
+                    return true;
+                }
+
+                classes.delete(token);
+                return false;
+            }
+
+            if (classes.has(token)) {
+                classes.delete(token);
+                return false;
+            }
+
+            classes.add(token);
+            return true;
+        },
+        contains(token) {
+            return classes.has(token);
+        },
+        toArray() {
+            return [...classes];
+        }
+    };
+}
+
+function createElement({
+    tagName = "div",
+    id = "",
+    name = "",
+    dataset = {},
+    attributes = {},
+    classNames = [],
+    value = "",
+    checked = false
+} = {}) {
+    const elementTarget = createEventTarget();
+    const attributeMap = new Map(Object.entries(attributes));
+
+    const element = {
+        ...elementTarget,
+        tagName: tagName.toUpperCase(),
+        id,
+        name,
+        dataset: { ...dataset },
+        classList: createClassList(classNames),
+        children: [],
+        parentNode: null,
+        textContent: "",
+        value,
+        checked,
+        wasFocused: false,
+        _innerHTML: "",
+        appendChild(child) {
+            child.parentNode = this;
+            this.children.push(child);
+            return child;
+        },
+        replaceChildren(...children) {
+            this.children = [];
+            children.forEach(child => this.appendChild(child));
+        },
+        setAttribute(key, nextValue) {
+            const safeValue = String(nextValue);
+            attributeMap.set(key, safeValue);
+            if (key === "id") {
+                this.id = safeValue;
+            }
+            if (key === "name") {
+                this.name = safeValue;
+            }
+            if (key.startsWith("data-")) {
+                this.dataset[toDatasetKey(key)] = safeValue;
+            }
+        },
+        getAttribute(key) {
+            if (key.startsWith("data-")) {
+                const dataValue = this.dataset[toDatasetKey(key)];
+                return typeof dataValue === "string" ? dataValue : null;
+            }
+
+            if (key === "name" && this.name) {
+                return this.name;
+            }
+
+            return attributeMap.has(key) ? attributeMap.get(key) : null;
+        },
+        removeAttribute(key) {
+            attributeMap.delete(key);
+            if (key.startsWith("data-")) {
+                delete this.dataset[toDatasetKey(key)];
+            }
+        },
+        focus() {
+            this.wasFocused = true;
+        },
+        reset() {
+            getDescendants(this).forEach(descendant => {
+                if (descendant.tagName === "INPUT" || descendant.tagName === "TEXTAREA") {
+                    descendant.value = "";
+                    descendant.checked = false;
+                }
+            });
+        },
+        closest(selector) {
+            let current = this;
+            while (current) {
+                if (matchesSelector(current, selector)) {
+                    return current;
+                }
+                current = current.parentNode;
+            }
+
+            return null;
+        },
+        contains(candidate) {
+            let current = candidate;
+            while (current) {
+                if (current === this) {
+                    return true;
+                }
+                current = current.parentNode;
+            }
+
+            return false;
+        },
+        querySelector(selector) {
+            return queryWithin(this, selector, true);
+        },
+        querySelectorAll(selector) {
+            return queryWithin(this, selector, false);
+        }
+    };
+
+    Object.defineProperty(element, "innerHTML", {
+        get() {
+            return element._innerHTML;
+        },
+        set(nextValue) {
+            element._innerHTML = String(nextValue);
+            element.children = [];
+
+            if (element.dataset.itemList) {
+                parseProductivityListHTML(element, element._innerHTML);
+            }
+        }
+    });
+
+    return element;
+}
+
+function getDescendants(node) {
+    const descendants = [];
+
+    node.children.forEach(child => {
+        descendants.push(child, ...getDescendants(child));
+    });
+
+    return descendants;
+}
+
+function matchesSelector(element, selector) {
+    const trimmed = selector.trim();
+
+    if (!trimmed) {
+        return false;
+    }
+
+    if (trimmed.includes(",")) {
+        return trimmed.split(",").some(part => matchesSelector(element, part));
+    }
+
+    if (trimmed.startsWith("#")) {
+        return element.id === trimmed.slice(1);
+    }
+
+    if (trimmed === "input" || trimmed === "textarea") {
+        return element.tagName === trimmed.toUpperCase();
+    }
+
+    const attributeMatch = trimmed.match(/^\[([^=\]]+)(?:="([^"]*)")?\]$/);
+    if (!attributeMatch) {
+        return false;
+    }
+
+    const [, rawAttribute, expectedValue] = attributeMatch;
+    let actualValue = null;
+
+    if (rawAttribute.startsWith("data-")) {
+        actualValue = element.dataset[toDatasetKey(rawAttribute)];
+    } else if (rawAttribute === "name") {
+        actualValue = element.name;
+    } else {
+        actualValue = element.getAttribute(rawAttribute);
+    }
+
+    if (typeof expectedValue === "undefined") {
+        return actualValue !== null && typeof actualValue !== "undefined";
+    }
+
+    return actualValue === expectedValue;
+}
+
+function queryWithin(root, selector, firstOnly) {
+    const trimmed = selector.trim();
+    if (!trimmed) {
+        return firstOnly ? null : [];
+    }
+
+    if (trimmed.includes(",")) {
+        const results = [];
+        trimmed.split(",").map(part => part.trim()).forEach(part => {
+            const matched = queryWithin(root, part, false);
+            matched.forEach(element => {
+                if (!results.includes(element)) {
+                    results.push(element);
+                }
+            });
+        });
+        return firstOnly ? (results[0] || null) : results;
+    }
+
+    const descendantMatch = trimmed.match(/^(.+)\s+(.+)$/);
+    if (descendantMatch) {
+        const [, ancestorSelector, childSelector] = descendantMatch;
+        const results = [];
+        queryWithin(root, ancestorSelector, false).forEach(ancestor => {
+            queryWithin(ancestor, childSelector, false).forEach(match => {
+                if (!results.includes(match)) {
+                    results.push(match);
+                }
+            });
+        });
+        return firstOnly ? (results[0] || null) : results;
+    }
+
+    const matches = getDescendants(root).filter(element => matchesSelector(element, trimmed));
+    return firstOnly ? (matches[0] || null) : matches;
+}
+
+function parseProductivityListHTML(listElement, html) {
+    const itemPattern = /<li class="([^"]*)" data-item-id="([^"]+)" data-item-type="([^"]+)">([\s\S]*?)<\/li>/g;
+    let match = itemPattern.exec(html);
+
+    while (match) {
+        const [, classAttr, itemId, itemType, body] = match;
+        const itemElement = createElement({
+            tagName: "li",
+            dataset: {
+                itemId,
+                itemType
+            },
+            classNames: classAttr.split(/\s+/).filter(Boolean)
+        });
+
+        const actionPattern = /data-action="([^"]+)"/g;
+        let actionMatch = actionPattern.exec(body);
+
+        while (actionMatch) {
+            itemElement.appendChild(createElement({
+                tagName: "button",
+                dataset: {
+                    action: actionMatch[1]
+                }
+            }));
+            actionMatch = actionPattern.exec(body);
+        }
+
+        const editFieldMatch = body.match(/data-edit-field="([^"]+)"/);
+        if (editFieldMatch) {
+            if (editFieldMatch[1] === "todo") {
+                const valueMatch = body.match(/value="([^"]*)"/);
+                itemElement.appendChild(createElement({
+                    tagName: "input",
+                    name: "text",
+                    dataset: {
+                        editField: "todo"
+                    },
+                    value: decodeHtml(valueMatch?.[1] || "")
+                }));
+            } else {
+                const textareaMatch = body.match(/<textarea[\s\S]*?>([\s\S]*?)<\/textarea>/);
+                itemElement.appendChild(createElement({
+                    tagName: "textarea",
+                    name: "content",
+                    dataset: {
+                        editField: "notes"
+                    },
+                    value: decodeHtml(textareaMatch?.[1] || "")
+                }));
+            }
+        }
+
+        if (body.includes('data-action="toggle-complete"')) {
+            const checkbox = createElement({
+                tagName: "input",
+                dataset: {
+                    action: "toggle-complete"
+                },
+                checked: body.includes("checked")
+            });
+            itemElement.appendChild(checkbox);
+        }
+
+        listElement.appendChild(itemElement);
+        match = itemPattern.exec(html);
+    }
+}
+
+function createDocument(elements) {
+    const documentTarget = createEventTarget();
+    const roots = [...elements];
+    const rootNode = {
+        children: roots
+    };
+
+    return {
+        ...documentTarget,
+        getElementById(id) {
+            return roots.find(element => element.id === id) || null;
+        },
+        querySelector(selector) {
+            return queryWithin(rootNode, selector, true);
+        },
+        querySelectorAll(selector) {
+            return queryWithin(rootNode, selector, false);
+        }
+    };
+}
+
+export function bootstrapProductivityRuntime({ localStorage } = {}) {
+    const sharedStorage = localStorage || createLocalStorage();
+    const nextUuid = (() => {
+        let count = 0;
+        return () => {
+            count += 1;
+            return `test-uuid-${count}`;
+        };
+    })();
+
+    const todoInput = createElement({ tagName: "input", id: "todoInput", name: "text" });
+    const noteInput = createElement({ tagName: "textarea", id: "noteInput", name: "content" });
+    const todoMessage = createElement({ dataset: { formMessage: "todo" }, classNames: ["hidden"] });
+    const noteMessage = createElement({ dataset: { formMessage: "notes" }, classNames: ["hidden"] });
+
+    const todoForm = createElement({ tagName: "form", dataset: { entryForm: "todo" } });
+    todoForm.appendChild(todoInput);
+    todoForm.appendChild(todoMessage);
+
+    const notesForm = createElement({ tagName: "form", dataset: { entryForm: "notes" } });
+    notesForm.appendChild(noteInput);
+    notesForm.appendChild(noteMessage);
+
+    const todoList = createElement({ tagName: "ul", dataset: { itemList: "todo" } });
+    const notesList = createElement({ tagName: "ul", dataset: { itemList: "notes" } });
+    const todoEmpty = createElement({ dataset: { emptyState: "todo" } });
+    const notesEmpty = createElement({ dataset: { emptyState: "notes" } });
+
+    const todoPanel = createElement({
+        id: "productivity-panel-todo",
+        dataset: { tabPanel: "todo" },
+        classNames: ["productivity-panel"],
+        attributes: {
+            "aria-hidden": "false"
+        }
+    });
+    todoPanel.appendChild(todoForm);
+    todoPanel.appendChild(todoList);
+    todoPanel.appendChild(todoEmpty);
+
+    const notesPanel = createElement({
+        id: "productivity-panel-notes",
+        dataset: { tabPanel: "notes" },
+        classNames: ["productivity-panel", "hidden"],
+        attributes: {
+            "aria-hidden": "true"
+        }
+    });
+    notesPanel.appendChild(notesForm);
+    notesPanel.appendChild(notesList);
+    notesPanel.appendChild(notesEmpty);
+
+    const todoTab = createElement({
+        tagName: "button",
+        id: "productivity-tab-todo",
+        dataset: { tabTrigger: "todo" },
+        classNames: ["productivity-tab", "productivity-tab--active"],
+        attributes: {
+            "aria-selected": "true",
+            "aria-controls": "productivity-panel-todo"
+        }
+    });
+    todoTab.tabIndex = 0;
+
+    const notesTab = createElement({
+        tagName: "button",
+        id: "productivity-tab-notes",
+        dataset: { tabTrigger: "notes" },
+        classNames: ["productivity-tab"],
+        attributes: {
+            "aria-selected": "false",
+            "aria-controls": "productivity-panel-notes"
+        }
+    });
+    notesTab.tabIndex = -1;
+
+    const document = createDocument([todoTab, notesTab, todoPanel, notesPanel]);
+    const windowTarget = createEventTarget();
+    const context = {
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        },
+        document,
+        window: null,
+        location: {
+            href: "https://teclos.space/productivity",
+            pathname: "/productivity"
+        },
+        localStorage: sharedStorage,
+        crypto: {
+            randomUUID: nextUuid
+        },
+        Date,
+        Math,
+        JSON,
+        Number,
+        String,
+        Boolean,
+        Object,
+        Array,
+        Intl,
+        addEventListener(...args) {
+            return windowTarget.addEventListener(...args);
+        },
+        dispatchEvent(...args) {
+            return windowTarget.dispatchEvent(...args);
+        }
+    };
+
+    context.window = context;
+    vm.createContext(context);
+
+    const source = readFileSync(path.resolve("src/main/resources/static/js/productivity.js"), "utf8");
+    vm.runInContext(source, context, { filename: "productivity.js" });
+    document.dispatchEvent({ type: "DOMContentLoaded", target: document });
+
+    return {
+        window: context,
+        document,
+        localStorage: sharedStorage,
+        tabs: {
+            todo: todoTab,
+            notes: notesTab
+        },
+        panels: {
+            todo: todoPanel,
+            notes: notesPanel
+        },
+        forms: {
+            todo: todoForm,
+            notes: notesForm
+        },
+        inputs: {
+            todo: todoInput,
+            notes: noteInput
+        },
+        lists: {
+            todo: todoList,
+            notes: notesList
+        },
+        emptyStates: {
+            todo: todoEmpty,
+            notes: notesEmpty
+        },
+        messages: {
+            todo: todoMessage,
+            notes: noteMessage
+        }
+    };
+}
+
+export function submitForm(runtime, type) {
+    runtime.forms[type].dispatchEvent({
+        type: "submit",
+        target: runtime.forms[type]
+    });
+}
+
+export function inputValue(runtime, type, value) {
+    runtime.inputs[type].value = value;
+    runtime.forms[type].dispatchEvent({
+        type: "input",
+        target: runtime.inputs[type]
+    });
+}
+
+export function clickListAction(runtime, type, itemId, action) {
+    const actionElement = runtime.lists[type].querySelector(`[data-item-id="${itemId}"] [data-action="${action}"]`);
+    runtime.lists[type].dispatchEvent({
+        type: "click",
+        target: actionElement
+    });
+}
+
+export function toggleTodo(runtime, itemId, checked) {
+    const checkbox = runtime.lists.todo.querySelector(`[data-item-id="${itemId}"] [data-action="toggle-complete"]`);
+    checkbox.checked = checked;
+    runtime.lists.todo.dispatchEvent({
+        type: "change",
+        target: checkbox
+    });
+}
+
+export function triggerEditorKey(runtime, type, itemId, {
+    key = "Enter",
+    ctrlKey = false,
+    metaKey = false
+} = {}) {
+    const editor = runtime.lists[type].querySelector(`[data-item-id="${itemId}"] [data-edit-field="${type}"]`);
+    runtime.lists[type].dispatchEvent({
+        type: "keydown",
+        key,
+        ctrlKey,
+        metaKey,
+        target: editor
+    });
+}
+
+export function getStoredProductivityState(runtime) {
+    const raw = runtime.localStorage.getItem("telos.productivity.v1");
+    return raw ? JSON.parse(raw) : null;
+}
+
+export function dispatchStorageSync(runtime) {
+    runtime.window.dispatchEvent({
+        type: "storage",
+        key: "telos.productivity.v1"
+    });
+}

--- a/tests/unit-js/settings-validation.test.mjs
+++ b/tests/unit-js/settings-validation.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    createDocument,
+    createElement,
+    runBrowserScript
+} from "./dom-test-utils.mjs";
+
+function bootstrapSettingsPage() {
+    const settingsToggle = createElement({ tagName: "button", id: "settingsToggle" });
+    const timerSection = createElement({ id: "timerSection" });
+    const settingsSection = createElement({ id: "settingsSection", classNames: ["hidden"] });
+    const saveSettings = createElement({ tagName: "button", id: "saveSettings" });
+    const cancelSettings = createElement({ tagName: "button", id: "cancelSettings" });
+    const pomodoroTime = createElement({ tagName: "input", id: "pomodoroTime", value: "25" });
+    const shortBreakTime = createElement({ tagName: "input", id: "shortBreakTime", value: "5" });
+    const longBreakTime = createElement({ tagName: "input", id: "longBreakTime", value: "15" });
+    const soundEnabled = createElement({ tagName: "input", id: "soundEnabled" });
+    const focusCycles = createElement({ tagName: "input", id: "focusCycles", value: "1" });
+    const settingsError = createElement({ tagName: "p", id: "settingsError", classNames: ["hidden"] });
+    const authMeta = createElement({ tagName: "meta", attributes: { name: "is-authenticated", content: "false" } });
+
+    settingsSection.appendChild(pomodoroTime);
+    settingsSection.appendChild(shortBreakTime);
+    settingsSection.appendChild(longBreakTime);
+    settingsSection.appendChild(soundEnabled);
+    settingsSection.appendChild(focusCycles);
+    settingsSection.appendChild(settingsError);
+    settingsSection.appendChild(saveSettings);
+    settingsSection.appendChild(cancelSettings);
+
+    const document = createDocument([
+        authMeta,
+        settingsToggle,
+        timerSection,
+        settingsSection,
+        saveSettings,
+        cancelSettings,
+        pomodoroTime,
+        shortBreakTime,
+        longBreakTime,
+        soundEnabled,
+        focusCycles,
+        settingsError
+    ]);
+
+    let savedSettings = {
+        pomodoro: 25,
+        shortBreak: 5,
+        longBreak: 15,
+        soundEnabled: true,
+        focusCycles: 1
+    };
+    let saveCalls = [];
+
+    const context = {
+        document,
+        window: null,
+        fetch: async () => {
+            throw new Error("fetch should not be called for anonymous settings tests");
+        },
+        CustomEvent: class CustomEvent {
+            constructor(type, options = {}) {
+                this.type = type;
+                this.detail = options.detail;
+            }
+        },
+        PomodoroTimerState: {
+            keys: {
+                SETTINGS_KEY: "pomodoroSettings"
+            },
+            loadSettings() {
+                return { ...savedSettings };
+            },
+            normalizeSettings(nextValue) {
+                return {
+                    pomodoro: Number(nextValue.pomodoro),
+                    shortBreak: Number(nextValue.shortBreak),
+                    longBreak: Number(nextValue.longBreak),
+                    soundEnabled: Boolean(nextValue.soundEnabled),
+                    focusCycles: Number(nextValue.focusCycles)
+                };
+            },
+            saveSettings(nextValue) {
+                savedSettings = { ...nextValue };
+                saveCalls.push({ ...nextValue });
+                return { ...savedSettings };
+            }
+        },
+        JSON,
+        Date,
+        Math,
+        Number,
+        String,
+        Boolean,
+        Object,
+        Array,
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        },
+        addEventListener() {}
+    };
+    context.window = context;
+
+    runBrowserScript("src/main/resources/static/js/settings.js", context);
+
+    return {
+        settingsToggle,
+        timerSection,
+        settingsSection,
+        saveSettings,
+        pomodoroTime,
+        shortBreakTime,
+        longBreakTime,
+        focusCycles,
+        settingsError,
+        getSaveCalls() {
+            return saveCalls;
+        }
+    };
+}
+
+test("[ui-negative] settings validation rejects non-numeric values and keeps state unsaved", () => {
+    const runtime = bootstrapSettingsPage();
+
+    runtime.pomodoroTime.value = "abc";
+    runtime.saveSettings.dispatchEvent({ type: "click", target: runtime.saveSettings });
+
+    assert.equal(runtime.settingsError.classList.contains("hidden"), false);
+    assert.equal(runtime.settingsError.textContent, "Work must be a number.");
+    assert.equal(runtime.pomodoroTime.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.getSaveCalls().length, 0);
+});
+
+test("[ui-negative] settings validation rejects decimal values and keeps state unsaved", () => {
+    const runtime = bootstrapSettingsPage();
+
+    runtime.shortBreakTime.value = "2.5";
+    runtime.saveSettings.dispatchEvent({ type: "click", target: runtime.saveSettings });
+
+    assert.equal(runtime.settingsError.textContent, "Short break must be a whole number.");
+    assert.equal(runtime.shortBreakTime.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.getSaveCalls().length, 0);
+});
+
+test("[ui-negative] settings validation rejects empty and out-of-range values with field-specific messages", () => {
+    const runtime = bootstrapSettingsPage();
+
+    runtime.longBreakTime.value = "";
+    runtime.saveSettings.dispatchEvent({ type: "click", target: runtime.saveSettings });
+    assert.equal(runtime.settingsError.textContent, "Long break is required.");
+    assert.equal(runtime.getSaveCalls().length, 0);
+
+    runtime.longBreakTime.value = "90";
+    runtime.longBreakTime.dispatchEvent({ type: "input", target: runtime.longBreakTime });
+    runtime.saveSettings.dispatchEvent({ type: "click", target: runtime.saveSettings });
+    assert.equal(runtime.settingsError.textContent, "Long break must be between 1 and 80.");
+    assert.equal(runtime.getSaveCalls().length, 0);
+});
+
+test("[ui-negative] corrected settings clear the error state and persist only after a valid save", () => {
+    const runtime = bootstrapSettingsPage();
+
+    runtime.focusCycles.value = "0";
+    runtime.saveSettings.dispatchEvent({ type: "click", target: runtime.saveSettings });
+    assert.equal(runtime.settingsError.textContent, "Focus session cycles must be between 1 and 12.");
+    assert.equal(runtime.getSaveCalls().length, 0);
+
+    runtime.focusCycles.value = "3";
+    runtime.focusCycles.dispatchEvent({ type: "input", target: runtime.focusCycles });
+    assert.equal(runtime.settingsError.classList.contains("hidden"), true);
+
+    runtime.saveSettings.dispatchEvent({ type: "click", target: runtime.saveSettings });
+    assert.equal(runtime.getSaveCalls().length, 1);
+    assert.deepEqual(runtime.getSaveCalls()[0], {
+        pomodoro: 25,
+        shortBreak: 5,
+        longBreak: 15,
+        soundEnabled: true,
+        focusCycles: 3
+    });
+});

--- a/tests/unit-js/timer-persistence.test.mjs
+++ b/tests/unit-js/timer-persistence.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    loadTimerStateModule,
+    withMockedNow
+} from "./timer-state.test-utils.mjs";
+
+test("saves and loads normalized settings through localStorage", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+
+    const saved = timerState.saveSettings({
+        pomodoro: 40,
+        shortBreak: 8,
+        longBreak: 25,
+        soundEnabled: false,
+        focusCycles: 2
+    });
+    const stored = JSON.parse(localStorage.getItem(timerState.keys.SETTINGS_KEY));
+    const loaded = timerState.loadSettings();
+
+    assert.equal(saved.pomodoro, 40);
+    assert.equal(saved.shortBreak, 8);
+    assert.equal(saved.longBreak, 25);
+    assert.equal(saved.soundEnabled, false);
+    assert.equal(saved.focusCycles, 2);
+
+    assert.equal(stored.pomodoro, 40);
+    assert.equal(stored.shortBreak, 8);
+    assert.equal(stored.longBreak, 25);
+    assert.equal(stored.soundEnabled, false);
+    assert.equal(stored.focusCycles, 2);
+
+    assert.equal(loaded.pomodoro, 40);
+    assert.equal(loaded.shortBreak, 8);
+    assert.equal(loaded.longBreak, 25);
+    assert.equal(loaded.soundEnabled, false);
+    assert.equal(loaded.focusCycles, 2);
+});
+
+test("falls back safely when saved settings JSON is corrupted", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+
+    localStorage.setItem(timerState.keys.SETTINGS_KEY, "{invalid-json");
+    const loaded = timerState.loadSettings();
+
+    assert.equal(loaded.pomodoro, 25);
+    assert.equal(loaded.shortBreak, 5);
+    assert.equal(loaded.longBreak, 15);
+    assert.equal(loaded.soundEnabled, true);
+    assert.equal(loaded.focusCycles, 1);
+});
+
+test("normalizes invalid timer state values before persisting them", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const normalized = timerState.saveTimerState({
+        currentMode: "unsupported-mode",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: -10,
+        completedPomodorosInCycle: -5,
+        completedFocusCycles: -1
+    }, settings);
+
+    assert.equal(normalized.currentMode, "pomodoro");
+    assert.equal(normalized.remainingSeconds, 25 * 60);
+    assert.equal(normalized.completedPomodorosInCycle, 0);
+    assert.equal(normalized.completedFocusCycles, 0);
+    assert.ok(localStorage.getItem(timerState.keys.TIMER_STATE_KEY));
+});
+
+test("falls back to the default timer state when saved timer JSON is corrupted", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+
+    localStorage.setItem(timerState.keys.TIMER_STATE_KEY, "{broken-json");
+    const loaded = timerState.loadTimerState(settings);
+
+    assert.equal(loaded.currentMode, "pomodoro");
+    assert.equal(loaded.isRunning, false);
+    assert.equal(loaded.remainingSeconds, 25 * 60);
+});
+
+test("loads and persists timer state through localStorage without UI interaction", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const customState = {
+        currentMode: "short-break",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 5 * 60,
+        completedPomodorosInCycle: 1,
+        completedFocusCycles: 0
+    };
+
+    timerState.saveTimerState(customState, settings);
+    const stored = JSON.parse(localStorage.getItem(timerState.keys.TIMER_STATE_KEY));
+    const loaded = timerState.loadTimerState(settings);
+
+    assert.equal(stored.currentMode, "short-break");
+    assert.equal(stored.remainingSeconds, 5 * 60);
+
+    // Idle short-break states are intentionally normalized back to a fresh pomodoro state on load.
+    assert.equal(loaded.currentMode, "pomodoro");
+    assert.equal(loaded.isRunning, false);
+    assert.equal(loaded.remainingSeconds, 25 * 60);
+});
+
+test("persists timer state fields needed for later recovery", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const runningState = {
+        currentMode: "pomodoro",
+        isRunning: true,
+        endTime: 9_999_000,
+        remainingSeconds: 1_111,
+        completedPomodorosInCycle: 2,
+        completedFocusCycles: 1
+    };
+
+    timerState.saveTimerState(runningState, settings);
+    const stored = JSON.parse(localStorage.getItem(timerState.keys.TIMER_STATE_KEY));
+
+    assert.equal(stored.currentMode, "pomodoro");
+    assert.equal(stored.isRunning, true);
+    assert.equal(stored.endTime, 9_999_000);
+    assert.equal(stored.remainingSeconds, 1_111);
+    assert.equal(stored.completedPomodorosInCycle, 2);
+    assert.equal(stored.completedFocusCycles, 1);
+});
+
+test("restores a paused timer state after reload without changing its mode or remaining time", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const pausedState = {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 321,
+        completedPomodorosInCycle: 1,
+        completedFocusCycles: 0
+    };
+
+    timerState.saveTimerState(pausedState, settings);
+    const restored = withMockedNow(7_000_000, () => timerState.loadTimerState(settings));
+
+    assert.equal(restored.currentMode, "pomodoro");
+    assert.equal(restored.isRunning, false);
+    assert.equal(restored.endTime, null);
+    assert.equal(restored.remainingSeconds, 321);
+    assert.equal(restored.completedPomodorosInCycle, 1);
+    assert.equal(restored.completedFocusCycles, 0);
+});
+
+test("restores a running timer state after reload and recalculates remaining time from timestamp", () => {
+    const startAt = 8_000_000;
+
+    const restored = withMockedNow(startAt + 15_000, () => {
+        const { timerState } = loadTimerStateModule();
+        const settings = timerState.getDefaultSettings();
+        const running = timerState.startTimerState(
+            timerState.getDefaultTimerState(settings),
+            settings,
+            startAt
+        );
+
+        timerState.saveTimerState(running, settings);
+        return timerState.loadTimerState(settings);
+    });
+
+    assert.equal(restored.currentMode, "pomodoro");
+    assert.equal(restored.isRunning, true);
+    assert.equal(restored.remainingSeconds, (25 * 60) - 15);
+});
+
+test("recovery keeps a running timer in the next mode if the previous session finished while user was away", () => {
+    const settingsNow = 9_000_000;
+
+    const restored = withMockedNow(settingsNow, () => {
+        const { timerState, localStorage } = loadTimerStateModule();
+        const settings = timerState.getDefaultSettings();
+        const savedRunningPomodoro = {
+            currentMode: "pomodoro",
+            isRunning: true,
+            endTime: settingsNow - 10_000,
+            remainingSeconds: 1,
+            completedPomodorosInCycle: 0,
+            completedFocusCycles: 0
+        };
+
+        timerState.saveTimerState(savedRunningPomodoro, settings);
+        assert.ok(localStorage.getItem(timerState.keys.TIMER_STATE_KEY));
+        return timerState.loadTimerState(settings);
+    });
+
+    assert.equal(restored.currentMode, "short-break");
+    assert.equal(restored.isRunning, true);
+    assert.equal(restored.remainingSeconds, (5 * 60) - 10);
+    assert.equal(restored.completedPomodorosInCycle, 1);
+    assert.equal(restored.completedFocusCycles, 0);
+});

--- a/tests/unit-js/timer-state.test-utils.mjs
+++ b/tests/unit-js/timer-state.test-utils.mjs
@@ -2,8 +2,8 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
 
-function createLocalStorage() {
-    const store = new Map();
+export function createLocalStorage(initialEntries = {}) {
+    const store = new Map(Object.entries(initialEntries));
 
     return {
         getItem(key) {
@@ -17,6 +17,9 @@ function createLocalStorage() {
         },
         clear() {
             store.clear();
+        },
+        snapshot() {
+            return Object.fromEntries(store.entries());
         }
     };
 }

--- a/tests/unit-js/timer-state.test-utils.mjs
+++ b/tests/unit-js/timer-state.test-utils.mjs
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+
+function createLocalStorage() {
+    const store = new Map();
+
+    return {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, String(value));
+        },
+        removeItem(key) {
+            store.delete(key);
+        },
+        clear() {
+            store.clear();
+        }
+    };
+}
+
+export function loadTimerStateModule() {
+    const filePath = path.resolve("src/main/resources/static/js/timer-state.js");
+    const source = readFileSync(filePath, "utf8");
+    const localStorage = createLocalStorage();
+    const context = {
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        },
+        localStorage,
+        Date,
+        Math,
+        JSON,
+        Number,
+        String,
+        Boolean,
+        Object,
+        Array,
+        Intl
+    };
+
+    context.window = context;
+
+    vm.createContext(context);
+    vm.runInContext(source, context, { filename: "timer-state.js" });
+
+    return {
+        timerState: context.PomodoroTimerState,
+        localStorage
+    };
+}
+
+export function getStartedPomodoro(timerState, now = 1_000_000) {
+    const settings = timerState.getDefaultSettings();
+    const state = timerState.getDefaultTimerState(settings);
+
+    return {
+        now,
+        settings,
+        state,
+        started: timerState.startTimerState(state, settings, now)
+    };
+}
+
+export function withMockedNow(now, callback) {
+    const originalNow = Date.now;
+    Date.now = () => now;
+
+    try {
+        return callback();
+    } finally {
+        Date.now = originalNow;
+    }
+}

--- a/tests/unit-js/timer-state.test.mjs
+++ b/tests/unit-js/timer-state.test.mjs
@@ -1,0 +1,566 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+
+function createLocalStorage() {
+    const store = new Map();
+
+    return {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, String(value));
+        },
+        removeItem(key) {
+            store.delete(key);
+        },
+        clear() {
+            store.clear();
+        }
+    };
+}
+
+function loadTimerStateModule() {
+    const filePath = path.resolve("src/main/resources/static/js/timer-state.js");
+    const source = readFileSync(filePath, "utf8");
+    const localStorage = createLocalStorage();
+    const context = {
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        },
+        localStorage,
+        Date,
+        Math,
+        JSON,
+        Number,
+        String,
+        Boolean,
+        Object,
+        Array,
+        Intl
+    };
+
+    context.window = context;
+
+    vm.createContext(context);
+    vm.runInContext(source, context, { filename: "timer-state.js" });
+
+    return {
+        timerState: context.PomodoroTimerState,
+        localStorage
+    };
+}
+
+function getStartedPomodoro(timerState, now = 1_000_000) {
+    const settings = timerState.getDefaultSettings();
+    const state = timerState.getDefaultTimerState(settings);
+
+    return {
+        now,
+        settings,
+        state,
+        started: timerState.startTimerState(state, settings, now)
+    };
+}
+
+test("normalizes default and valid settings correctly", () => {
+    const { timerState } = loadTimerStateModule();
+
+    const defaults = timerState.getDefaultSettings();
+    const valid = timerState.normalizeSettings({
+        pomodoro: 50,
+        shortBreak: 10,
+        longBreak: 20,
+        soundEnabled: false,
+        focusCycles: 3
+    });
+
+    assert.equal(defaults.pomodoro, 25);
+    assert.equal(defaults.shortBreak, 5);
+    assert.equal(defaults.longBreak, 15);
+    assert.equal(defaults.soundEnabled, true);
+    assert.equal(defaults.focusCycles, 1);
+
+    assert.equal(valid.pomodoro, 50);
+    assert.equal(valid.shortBreak, 10);
+    assert.equal(valid.longBreak, 20);
+    assert.equal(valid.soundEnabled, false);
+    assert.equal(valid.focusCycles, 3);
+});
+
+test("clamps invalid settings and defaults soundEnabled to true unless explicitly false", () => {
+    const { timerState } = loadTimerStateModule();
+
+    const normalized = timerState.normalizeSettings({
+        pomodoro: -10,
+        shortBreak: 999,
+        longBreak: "not-a-number",
+        focusCycles: 0,
+        soundEnabled: undefined
+    });
+
+    assert.equal(normalized.pomodoro, 25);
+    assert.equal(normalized.shortBreak, 30);
+    assert.equal(normalized.longBreak, 15);
+    assert.equal(normalized.focusCycles, 1);
+    assert.equal(normalized.soundEnabled, true);
+});
+
+test("maps settings keys for each supported mode", () => {
+    const { timerState } = loadTimerStateModule();
+
+    assert.equal(timerState.getSettingsKey("pomodoro"), "pomodoro");
+    assert.equal(timerState.getSettingsKey("short-break"), "shortBreak");
+    assert.equal(timerState.getSettingsKey("long-break"), "longBreak");
+    assert.equal(timerState.getSettingsKey("unsupported-mode"), "pomodoro");
+});
+
+test("returns the default timer state for a fresh pomodoro session", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const state = timerState.getDefaultTimerState(settings);
+
+    assert.equal(state.currentMode, "pomodoro");
+    assert.equal(state.isRunning, false);
+    assert.equal(state.endTime, null);
+    assert.equal(state.remainingSeconds, 25 * 60);
+    assert.equal(state.completedPomodorosInCycle, 0);
+    assert.equal(state.completedFocusCycles, 0);
+});
+
+test("saves and loads normalized settings through localStorage", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+
+    const saved = timerState.saveSettings({
+        pomodoro: 40,
+        shortBreak: 8,
+        longBreak: 25,
+        soundEnabled: false,
+        focusCycles: 2
+    });
+    const stored = JSON.parse(localStorage.getItem(timerState.keys.SETTINGS_KEY));
+    const loaded = timerState.loadSettings();
+
+    assert.equal(saved.pomodoro, 40);
+    assert.equal(saved.shortBreak, 8);
+    assert.equal(saved.longBreak, 25);
+    assert.equal(saved.soundEnabled, false);
+    assert.equal(saved.focusCycles, 2);
+
+    assert.equal(stored.pomodoro, 40);
+    assert.equal(stored.shortBreak, 8);
+    assert.equal(stored.longBreak, 25);
+    assert.equal(stored.soundEnabled, false);
+    assert.equal(stored.focusCycles, 2);
+
+    assert.equal(loaded.pomodoro, 40);
+    assert.equal(loaded.shortBreak, 8);
+    assert.equal(loaded.longBreak, 25);
+    assert.equal(loaded.soundEnabled, false);
+    assert.equal(loaded.focusCycles, 2);
+});
+
+test("falls back safely when saved settings JSON is corrupted", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+
+    localStorage.setItem(timerState.keys.SETTINGS_KEY, "{invalid-json");
+    const loaded = timerState.loadSettings();
+
+    assert.equal(loaded.pomodoro, 25);
+    assert.equal(loaded.shortBreak, 5);
+    assert.equal(loaded.longBreak, 15);
+    assert.equal(loaded.soundEnabled, true);
+    assert.equal(loaded.focusCycles, 1);
+});
+
+test("starts a fresh pomodoro timer with the correct running state", () => {
+    const { timerState } = loadTimerStateModule();
+    const { now, started } = getStartedPomodoro(timerState);
+
+    assert.equal(started.currentMode, "pomodoro");
+    assert.equal(started.isRunning, true);
+    assert.equal(started.remainingSeconds, 25 * 60);
+    assert.equal(started.endTime, now + (25 * 60 * 1000));
+});
+
+test("starting an already running timer keeps it in a consistent running state", () => {
+    const { timerState } = loadTimerStateModule();
+    const { now, settings, started } = getStartedPomodoro(timerState);
+
+    const restarted = timerState.startTimerState(started, settings, now + 5_000);
+
+    assert.equal(restarted.isRunning, true);
+    assert.equal(restarted.currentMode, "pomodoro");
+    assert.equal(restarted.endTime, started.endTime);
+});
+
+test("pauses a running timer and keeps the remaining seconds", () => {
+    const { timerState } = loadTimerStateModule();
+    const { now, settings, started } = getStartedPomodoro(timerState);
+
+    const paused = timerState.pauseTimerState(started, settings, now + 10_000);
+
+    assert.equal(paused.currentMode, "pomodoro");
+    assert.equal(paused.isRunning, false);
+    assert.equal(paused.endTime, null);
+    assert.equal(paused.remainingSeconds, (25 * 60) - 10);
+});
+
+test("resets timer state back to a fresh pomodoro session", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+
+    const longBreakState = {
+        currentMode: "long-break",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 60,
+        completedPomodorosInCycle: 4,
+        completedFocusCycles: 1
+    };
+
+    const reset = timerState.resetTimerState(longBreakState, settings);
+
+    assert.equal(reset.currentMode, "pomodoro");
+    assert.equal(reset.isRunning, false);
+    assert.equal(reset.endTime, null);
+    assert.equal(reset.remainingSeconds, 25 * 60);
+    assert.equal(reset.completedPomodorosInCycle, 0);
+    assert.equal(reset.completedFocusCycles, 0);
+});
+
+test("recomputes paused remaining time when applying new settings and leaves running state untouched", () => {
+    const { timerState } = loadTimerStateModule();
+    const originalSettings = timerState.getDefaultSettings();
+    const newSettings = timerState.normalizeSettings({
+        pomodoro: 40,
+        shortBreak: 10,
+        longBreak: 30,
+        soundEnabled: true,
+        focusCycles: 2
+    });
+
+    const pausedState = {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 100,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 0
+    };
+    const now = Date.now();
+    const runningState = timerState.startTimerState(
+        timerState.getDefaultTimerState(originalSettings),
+        originalSettings,
+        now
+    );
+
+    const appliedPaused = timerState.applySettingsToTimerState(pausedState, newSettings);
+    const appliedRunning = timerState.applySettingsToTimerState(runningState, newSettings);
+
+    assert.equal(appliedPaused.remainingSeconds, 40 * 60);
+    assert.equal(appliedPaused.currentMode, "pomodoro");
+    assert.equal(appliedRunning.isRunning, true);
+    assert.equal(appliedRunning.endTime, runningState.endTime);
+});
+
+test("sets the requested current mode and falls back safely for an invalid mode", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const baseState = timerState.getDefaultTimerState(settings);
+
+    const shortBreak = timerState.setModeState(baseState, settings, "short-break");
+    const invalid = timerState.setModeState(baseState, settings, "unsupported-mode");
+
+    assert.equal(shortBreak.currentMode, "short-break");
+    assert.equal(shortBreak.remainingSeconds, 5 * 60);
+    assert.equal(shortBreak.isRunning, false);
+
+    assert.equal(invalid.currentMode, "pomodoro");
+    assert.equal(invalid.remainingSeconds, 25 * 60);
+});
+
+test("transitions from pomodoro to short break when a work session completes", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const completedAt = 2_000_000;
+
+    const runningPomodoro = {
+        currentMode: "pomodoro",
+        isRunning: true,
+        endTime: completedAt,
+        remainingSeconds: 0,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 0
+    };
+
+    const next = timerState.hydrateTimerState(runningPomodoro, settings, completedAt);
+
+    assert.equal(next.currentMode, "short-break");
+    assert.equal(next.isRunning, true);
+    assert.equal(next.completedPomodorosInCycle, 1);
+    assert.equal(next.completedFocusCycles, 0);
+    assert.equal(next.remainingSeconds, 5 * 60);
+});
+
+test("transitions from the fourth pomodoro to a long break", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const completedAt = 3_000_000;
+
+    const fourthPomodoro = {
+        currentMode: "pomodoro",
+        isRunning: true,
+        endTime: completedAt,
+        remainingSeconds: 0,
+        completedPomodorosInCycle: 3,
+        completedFocusCycles: 0
+    };
+
+    const next = timerState.hydrateTimerState(fourthPomodoro, settings, completedAt);
+
+    assert.equal(next.currentMode, "long-break");
+    assert.equal(next.isRunning, true);
+    assert.equal(next.completedPomodorosInCycle, 4);
+    assert.equal(next.completedFocusCycles, 0);
+    assert.equal(next.remainingSeconds, 15 * 60);
+});
+
+test("transitions from short break back to pomodoro when the break completes", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const completedAt = 3_500_000;
+
+    const shortBreak = {
+        currentMode: "short-break",
+        isRunning: true,
+        endTime: completedAt,
+        remainingSeconds: 0,
+        completedPomodorosInCycle: 2,
+        completedFocusCycles: 0
+    };
+
+    const next = timerState.hydrateTimerState(shortBreak, settings, completedAt);
+
+    assert.equal(next.currentMode, "pomodoro");
+    assert.equal(next.isRunning, true);
+    assert.equal(next.remainingSeconds, 25 * 60);
+    assert.equal(next.completedPomodorosInCycle, 2);
+});
+
+test("transitions from long break into the next focus cycle when more cycles remain", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.normalizeSettings({
+        pomodoro: 25,
+        shortBreak: 5,
+        longBreak: 15,
+        focusCycles: 2,
+        soundEnabled: true
+    });
+    const completedAt = 3_750_000;
+
+    const longBreak = {
+        currentMode: "long-break",
+        isRunning: true,
+        endTime: completedAt,
+        remainingSeconds: 0,
+        completedPomodorosInCycle: 4,
+        completedFocusCycles: 0
+    };
+
+    const next = timerState.hydrateTimerState(longBreak, settings, completedAt);
+
+    assert.equal(next.currentMode, "pomodoro");
+    assert.equal(next.isRunning, true);
+    assert.equal(next.remainingSeconds, 25 * 60);
+    assert.equal(next.completedPomodorosInCycle, 0);
+    assert.equal(next.completedFocusCycles, 1);
+});
+
+test("completes the final long break and marks the focus session as finished", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.normalizeSettings({
+        pomodoro: 25,
+        shortBreak: 5,
+        longBreak: 15,
+        focusCycles: 1,
+        soundEnabled: true
+    });
+    const completedAt = 4_000_000;
+
+    const finalLongBreak = {
+        currentMode: "long-break",
+        isRunning: true,
+        endTime: completedAt,
+        remainingSeconds: 0,
+        completedPomodorosInCycle: 4,
+        completedFocusCycles: 0
+    };
+
+    const next = timerState.hydrateTimerState(finalLongBreak, settings, completedAt);
+
+    assert.equal(next.currentMode, "pomodoro");
+    assert.equal(next.isRunning, false);
+    assert.equal(next.endTime, null);
+    assert.equal(next.remainingSeconds, 25 * 60);
+    assert.equal(next.completedPomodorosInCycle, 0);
+    assert.equal(next.completedFocusCycles, 1);
+    assert.equal(timerState.isFocusSessionFinished(next, settings), true);
+});
+
+test("returns current pomodoro and focus cycle numbers across states", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.normalizeSettings({
+        pomodoro: 25,
+        shortBreak: 5,
+        longBreak: 15,
+        focusCycles: 3,
+        soundEnabled: true
+    });
+    const fresh = timerState.getDefaultTimerState(settings);
+    const secondBreak = {
+        currentMode: "short-break",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 5 * 60,
+        completedPomodorosInCycle: 2,
+        completedFocusCycles: 0
+    };
+    const finished = {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 25 * 60,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 3
+    };
+
+    assert.equal(timerState.getCurrentPomodoroNumber(fresh), 1);
+    assert.equal(timerState.getCurrentPomodoroNumber(secondBreak), 2);
+    assert.equal(timerState.getCurrentFocusCycleNumber(fresh, settings), 1);
+    assert.equal(timerState.getCurrentFocusCycleNumber(finished, settings), 3);
+});
+
+test("computes projected session end time and returns null once the session is finished", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.normalizeSettings({
+        pomodoro: 1,
+        shortBreak: 1,
+        longBreak: 1,
+        focusCycles: 1,
+        soundEnabled: true
+    });
+    const fresh = timerState.getDefaultTimerState(settings);
+    const finished = {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 60,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 1
+    };
+
+    const projection = timerState.getProjectedSessionEndTime(fresh, settings, 10_000);
+
+    assert.equal(typeof projection, "number");
+    assert.ok(projection > 10_000);
+    assert.equal(timerState.getProjectedSessionEndTime(finished, settings, 10_000), null);
+});
+
+test("compares timer states by all persisted fields", () => {
+    const { timerState } = loadTimerStateModule();
+    const stateA = {
+        currentMode: "pomodoro",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 100,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 0
+    };
+    const stateB = { ...stateA };
+    const stateC = { ...stateA, remainingSeconds: 99 };
+
+    assert.equal(timerState.areStatesEqual(stateA, stateB), true);
+    assert.equal(timerState.areStatesEqual(stateA, stateC), false);
+});
+
+test("normalizes invalid timer state values and corrupted timer JSON safely", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const normalized = timerState.saveTimerState({
+        currentMode: "unsupported-mode",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: -10,
+        completedPomodorosInCycle: -5,
+        completedFocusCycles: -1
+    }, settings);
+
+    assert.equal(normalized.currentMode, "pomodoro");
+    assert.equal(normalized.remainingSeconds, 25 * 60);
+    assert.equal(normalized.completedPomodorosInCycle, 0);
+    assert.equal(normalized.completedFocusCycles, 0);
+
+    localStorage.setItem(timerState.keys.TIMER_STATE_KEY, "{broken-json");
+    const loaded = timerState.loadTimerState(settings);
+
+    assert.equal(loaded.currentMode, "pomodoro");
+    assert.equal(loaded.isRunning, false);
+    assert.equal(loaded.remainingSeconds, 25 * 60);
+});
+
+test("loads and persists timer state through localStorage without UI interaction", () => {
+    const { timerState, localStorage } = loadTimerStateModule();
+    const settings = timerState.getDefaultSettings();
+    const customState = {
+        currentMode: "short-break",
+        isRunning: false,
+        endTime: null,
+        remainingSeconds: 5 * 60,
+        completedPomodorosInCycle: 1,
+        completedFocusCycles: 0
+    };
+
+    timerState.saveTimerState(customState, settings);
+    const stored = JSON.parse(localStorage.getItem(timerState.keys.TIMER_STATE_KEY));
+    const loaded = timerState.loadTimerState(settings);
+
+    assert.equal(stored.currentMode, "short-break");
+    assert.equal(stored.remainingSeconds, 5 * 60);
+
+    // Idle short-break states are intentionally normalized back to a fresh pomodoro state on load.
+    assert.equal(loaded.currentMode, "pomodoro");
+    assert.equal(loaded.isRunning, false);
+    assert.equal(loaded.remainingSeconds, 25 * 60);
+});
+
+test("handles a pathological elapsed running state without producing invalid output", () => {
+    const { timerState } = loadTimerStateModule();
+    const settings = timerState.normalizeSettings({
+        pomodoro: 1,
+        shortBreak: 1,
+        longBreak: 1,
+        focusCycles: 50,
+        soundEnabled: true
+    });
+    const pathological = {
+        currentMode: "pomodoro",
+        isRunning: true,
+        endTime: 1_000,
+        remainingSeconds: 60,
+        completedPomodorosInCycle: 0,
+        completedFocusCycles: 0
+    };
+
+    const hydrated = timerState.hydrateTimerState(pathological, settings, 1_000 + (10_000 * 60 * 1000));
+
+    assert.ok(["pomodoro", "short-break", "long-break"].includes(hydrated.currentMode));
+    assert.equal(hydrated.remainingSeconds >= 0, true);
+    assert.equal(typeof hydrated.completedPomodorosInCycle, "number");
+    assert.equal(typeof hydrated.completedFocusCycles, "number");
+});

--- a/tests/unit-js/timer-state.test.mjs
+++ b/tests/unit-js/timer-state.test.mjs
@@ -1,72 +1,10 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import path from "node:path";
 import test from "node:test";
-import vm from "node:vm";
 
-function createLocalStorage() {
-    const store = new Map();
-
-    return {
-        getItem(key) {
-            return store.has(key) ? store.get(key) : null;
-        },
-        setItem(key, value) {
-            store.set(key, String(value));
-        },
-        removeItem(key) {
-            store.delete(key);
-        },
-        clear() {
-            store.clear();
-        }
-    };
-}
-
-function loadTimerStateModule() {
-    const filePath = path.resolve("src/main/resources/static/js/timer-state.js");
-    const source = readFileSync(filePath, "utf8");
-    const localStorage = createLocalStorage();
-    const context = {
-        console: {
-            warn() {},
-            log() {},
-            error() {}
-        },
-        localStorage,
-        Date,
-        Math,
-        JSON,
-        Number,
-        String,
-        Boolean,
-        Object,
-        Array,
-        Intl
-    };
-
-    context.window = context;
-
-    vm.createContext(context);
-    vm.runInContext(source, context, { filename: "timer-state.js" });
-
-    return {
-        timerState: context.PomodoroTimerState,
-        localStorage
-    };
-}
-
-function getStartedPomodoro(timerState, now = 1_000_000) {
-    const settings = timerState.getDefaultSettings();
-    const state = timerState.getDefaultTimerState(settings);
-
-    return {
-        now,
-        settings,
-        state,
-        started: timerState.startTimerState(state, settings, now)
-    };
-}
+import {
+    getStartedPomodoro,
+    loadTimerStateModule
+} from "./timer-state.test-utils.mjs";
 
 test("normalizes default and valid settings correctly", () => {
     const { timerState } = loadTimerStateModule();
@@ -131,51 +69,6 @@ test("returns the default timer state for a fresh pomodoro session", () => {
     assert.equal(state.remainingSeconds, 25 * 60);
     assert.equal(state.completedPomodorosInCycle, 0);
     assert.equal(state.completedFocusCycles, 0);
-});
-
-test("saves and loads normalized settings through localStorage", () => {
-    const { timerState, localStorage } = loadTimerStateModule();
-
-    const saved = timerState.saveSettings({
-        pomodoro: 40,
-        shortBreak: 8,
-        longBreak: 25,
-        soundEnabled: false,
-        focusCycles: 2
-    });
-    const stored = JSON.parse(localStorage.getItem(timerState.keys.SETTINGS_KEY));
-    const loaded = timerState.loadSettings();
-
-    assert.equal(saved.pomodoro, 40);
-    assert.equal(saved.shortBreak, 8);
-    assert.equal(saved.longBreak, 25);
-    assert.equal(saved.soundEnabled, false);
-    assert.equal(saved.focusCycles, 2);
-
-    assert.equal(stored.pomodoro, 40);
-    assert.equal(stored.shortBreak, 8);
-    assert.equal(stored.longBreak, 25);
-    assert.equal(stored.soundEnabled, false);
-    assert.equal(stored.focusCycles, 2);
-
-    assert.equal(loaded.pomodoro, 40);
-    assert.equal(loaded.shortBreak, 8);
-    assert.equal(loaded.longBreak, 25);
-    assert.equal(loaded.soundEnabled, false);
-    assert.equal(loaded.focusCycles, 2);
-});
-
-test("falls back safely when saved settings JSON is corrupted", () => {
-    const { timerState, localStorage } = loadTimerStateModule();
-
-    localStorage.setItem(timerState.keys.SETTINGS_KEY, "{invalid-json");
-    const loaded = timerState.loadSettings();
-
-    assert.equal(loaded.pomodoro, 25);
-    assert.equal(loaded.shortBreak, 5);
-    assert.equal(loaded.longBreak, 15);
-    assert.equal(loaded.soundEnabled, true);
-    assert.equal(loaded.focusCycles, 1);
 });
 
 test("starts a fresh pomodoro timer with the correct running state", () => {
@@ -414,7 +307,7 @@ test("completes the final long break and marks the focus session as finished", (
 });
 
 test("returns current pomodoro and focus cycle numbers across states", () => {
-    const { timerState, localStorage } = loadTimerStateModule();
+    const { timerState } = loadTimerStateModule();
     const settings = timerState.normalizeSettings({
         pomodoro: 25,
         shortBreak: 5,
@@ -487,56 +380,6 @@ test("compares timer states by all persisted fields", () => {
 
     assert.equal(timerState.areStatesEqual(stateA, stateB), true);
     assert.equal(timerState.areStatesEqual(stateA, stateC), false);
-});
-
-test("normalizes invalid timer state values and corrupted timer JSON safely", () => {
-    const { timerState, localStorage } = loadTimerStateModule();
-    const settings = timerState.getDefaultSettings();
-    const normalized = timerState.saveTimerState({
-        currentMode: "unsupported-mode",
-        isRunning: false,
-        endTime: null,
-        remainingSeconds: -10,
-        completedPomodorosInCycle: -5,
-        completedFocusCycles: -1
-    }, settings);
-
-    assert.equal(normalized.currentMode, "pomodoro");
-    assert.equal(normalized.remainingSeconds, 25 * 60);
-    assert.equal(normalized.completedPomodorosInCycle, 0);
-    assert.equal(normalized.completedFocusCycles, 0);
-
-    localStorage.setItem(timerState.keys.TIMER_STATE_KEY, "{broken-json");
-    const loaded = timerState.loadTimerState(settings);
-
-    assert.equal(loaded.currentMode, "pomodoro");
-    assert.equal(loaded.isRunning, false);
-    assert.equal(loaded.remainingSeconds, 25 * 60);
-});
-
-test("loads and persists timer state through localStorage without UI interaction", () => {
-    const { timerState, localStorage } = loadTimerStateModule();
-    const settings = timerState.getDefaultSettings();
-    const customState = {
-        currentMode: "short-break",
-        isRunning: false,
-        endTime: null,
-        remainingSeconds: 5 * 60,
-        completedPomodorosInCycle: 1,
-        completedFocusCycles: 0
-    };
-
-    timerState.saveTimerState(customState, settings);
-    const stored = JSON.parse(localStorage.getItem(timerState.keys.TIMER_STATE_KEY));
-    const loaded = timerState.loadTimerState(settings);
-
-    assert.equal(stored.currentMode, "short-break");
-    assert.equal(stored.remainingSeconds, 5 * 60);
-
-    // Idle short-break states are intentionally normalized back to a fresh pomodoro state on load.
-    assert.equal(loaded.currentMode, "pomodoro");
-    assert.equal(loaded.isRunning, false);
-    assert.equal(loaded.remainingSeconds, 25 * 60);
 });
 
 test("handles a pathological elapsed running state without producing invalid output", () => {

--- a/tests/unit-js/user-profile-validation.test.mjs
+++ b/tests/unit-js/user-profile-validation.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    createDocument,
+    createElement,
+    runBrowserScript
+} from "./dom-test-utils.mjs";
+
+async function flushAsyncWork() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function createFetchRecorder() {
+    const calls = [];
+
+    return {
+        calls,
+        fetch: async (url, options = {}) => {
+            calls.push({ url, options });
+            return {
+                ok: true,
+                async json() {
+                    if (url.includes("/username")) {
+                        const body = JSON.parse(options.body);
+                        return {
+                            username: body.username,
+                            message: "Username updated"
+                        };
+                    }
+
+                    return {
+                        message: "Password updated"
+                    };
+                }
+            };
+        }
+    };
+}
+
+function bootstrapUserProfilePage() {
+    const usernameForm = createElement({ tagName: "form", id: "username-form" });
+    const usernameTitle = createElement({ tagName: "h3", classNames: ["profile-panel-title"], content: "Profile Data" });
+    const usernameInput = createElement({ tagName: "input", id: "username", name: "username", value: "demo-user", classNames: ["settings-input", "auth-input"] });
+    const usernameError = createElement({ tagName: "p", dataset: { errorFor: "username" }, classNames: ["form-field-error", "hidden"] });
+    const usernameMessage = createElement({ tagName: "p", id: "username-message", classNames: ["form-message", "hidden"] });
+    const usernameSubmit = createElement({ tagName: "button", classNames: ["auth-submit"] });
+    usernameForm.appendChild(usernameTitle);
+    usernameForm.appendChild(usernameInput);
+    usernameForm.appendChild(usernameError);
+    usernameForm.appendChild(usernameMessage);
+    usernameForm.appendChild(usernameSubmit);
+
+    const passwordForm = createElement({ tagName: "form", id: "password-form" });
+    const passwordTitle = createElement({ tagName: "h3", classNames: ["profile-panel-title"], content: "Change Password" });
+    const oldPasswordInput = createElement({ tagName: "input", id: "oldPassword", name: "oldPassword", classNames: ["settings-input", "auth-input"] });
+    const oldPasswordError = createElement({ tagName: "p", dataset: { errorFor: "oldPassword" }, classNames: ["form-field-error", "hidden"] });
+    const newPasswordInput = createElement({ tagName: "input", id: "newPassword", name: "newPassword", classNames: ["settings-input", "auth-input"] });
+    const newPasswordError = createElement({ tagName: "p", dataset: { errorFor: "newPassword" }, classNames: ["form-field-error", "hidden"] });
+    const confirmNewPasswordInput = createElement({ tagName: "input", id: "confirmNewPassword", name: "confirmNewPassword", classNames: ["settings-input", "auth-input"] });
+    const confirmNewPasswordError = createElement({ tagName: "p", dataset: { errorFor: "confirmNewPassword" }, classNames: ["form-field-error", "hidden"] });
+    const passwordMessage = createElement({ tagName: "p", id: "password-message", classNames: ["form-message", "hidden"] });
+    const passwordSubmit = createElement({ tagName: "button", classNames: ["auth-submit"] });
+    passwordForm.appendChild(passwordTitle);
+    passwordForm.appendChild(oldPasswordInput);
+    passwordForm.appendChild(oldPasswordError);
+    passwordForm.appendChild(newPasswordInput);
+    passwordForm.appendChild(newPasswordError);
+    passwordForm.appendChild(confirmNewPasswordInput);
+    passwordForm.appendChild(confirmNewPasswordError);
+    passwordForm.appendChild(passwordMessage);
+    passwordForm.appendChild(passwordSubmit);
+
+    const csrfTokenMeta = createElement({ tagName: "meta", attributes: { name: "_csrf", content: "csrf-token" } });
+    const csrfHeaderMeta = createElement({ tagName: "meta", attributes: { name: "_csrf_header", content: "X-CSRF-TOKEN" } });
+
+    const document = createDocument([
+        csrfTokenMeta,
+        csrfHeaderMeta,
+        usernameForm,
+        passwordForm
+    ]);
+    const fetchRecorder = createFetchRecorder();
+    const context = {
+        document,
+        window: null,
+        fetch: fetchRecorder.fetch,
+        JSON,
+        Date,
+        Math,
+        Number,
+        String,
+        Boolean,
+        Object,
+        Array,
+        console: {
+            warn() {},
+            log() {},
+            error() {}
+        }
+    };
+    context.window = context;
+
+    runBrowserScript("src/main/resources/static/js/user-settings.js", context);
+    document.dispatchEvent({ type: "DOMContentLoaded", target: document });
+
+    return {
+        fetchCalls: fetchRecorder.calls,
+        usernameForm,
+        usernameInput,
+        usernameError,
+        usernameMessage,
+        passwordForm,
+        oldPasswordInput,
+        oldPasswordError,
+        newPasswordInput,
+        newPasswordError,
+        confirmNewPasswordInput,
+        confirmNewPasswordError,
+        passwordMessage,
+        usernameTitle,
+        passwordTitle
+    };
+}
+
+test("profile page exposes separate profile data and change password sections", () => {
+    const runtime = bootstrapUserProfilePage();
+
+    assert.ok(runtime.usernameForm);
+    assert.ok(runtime.passwordForm);
+    assert.equal(runtime.usernameTitle.textContent, "Profile Data");
+    assert.equal(runtime.passwordTitle.textContent, "Change Password");
+});
+
+test("password validation blocks mismatched confirmation and short passwords with error state", () => {
+    const runtime = bootstrapUserProfilePage();
+
+    runtime.oldPasswordInput.value = "current-password";
+    runtime.newPasswordInput.value = "short";
+    runtime.confirmNewPasswordInput.value = "different";
+
+    const submitEvent = {
+        type: "submit",
+        target: runtime.passwordForm
+    };
+    runtime.passwordForm.dispatchEvent(submitEvent);
+
+    assert.equal(submitEvent.defaultPrevented, true);
+    assert.equal(runtime.newPasswordInput.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.confirmNewPasswordInput.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.newPasswordError.classList.contains("hidden"), false);
+    assert.equal(runtime.confirmNewPasswordError.classList.contains("hidden"), false);
+    assert.ok(runtime.newPasswordError.textContent.includes("at least 8"));
+    assert.ok(runtime.confirmNewPasswordError.textContent.includes("do not match"));
+    assert.equal(runtime.fetchCalls.length, 0);
+});
+
+test("valid password data passes frontend validation and submits without backend auth integration", async () => {
+    const runtime = bootstrapUserProfilePage();
+
+    runtime.oldPasswordInput.value = "current-password";
+    runtime.newPasswordInput.value = "long-enough-password";
+    runtime.confirmNewPasswordInput.value = "long-enough-password";
+
+    const submitEvent = {
+        type: "submit",
+        target: runtime.passwordForm
+    };
+    runtime.passwordForm.dispatchEvent(submitEvent);
+    await flushAsyncWork();
+
+    assert.equal(runtime.fetchCalls.length, 1);
+    assert.equal(runtime.fetchCalls[0].url, "/api/user/password");
+    assert.equal(runtime.passwordMessage.classList.contains("hidden"), false);
+    assert.equal(runtime.passwordMessage.classList.contains("form-message--success"), true);
+    assert.equal(runtime.oldPasswordInput.value, "");
+    assert.equal(runtime.newPasswordInput.value, "");
+    assert.equal(runtime.confirmNewPasswordInput.value, "");
+});
+
+test("blank username is blocked client-side and valid username submission succeeds", async () => {
+    const runtime = bootstrapUserProfilePage();
+
+    runtime.usernameInput.value = "   ";
+    let submitEvent = {
+        type: "submit",
+        target: runtime.usernameForm
+    };
+    runtime.usernameForm.dispatchEvent(submitEvent);
+    await flushAsyncWork();
+
+    assert.equal(runtime.fetchCalls.length, 0);
+    assert.equal(runtime.usernameInput.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.usernameError.classList.contains("hidden"), false);
+
+    runtime.usernameInput.value = "updated-user";
+    runtime.usernameInput.dispatchEvent({ type: "input", target: runtime.usernameInput });
+    submitEvent = {
+        type: "submit",
+        target: runtime.usernameForm
+    };
+    runtime.usernameForm.dispatchEvent(submitEvent);
+    await flushAsyncWork();
+
+    assert.equal(runtime.fetchCalls.length, 1);
+    assert.equal(runtime.fetchCalls[0].url, "/api/user/username");
+    assert.equal(runtime.usernameMessage.classList.contains("hidden"), false);
+    assert.equal(runtime.usernameMessage.classList.contains("form-message--success"), true);
+    assert.equal(runtime.usernameInput.value, "updated-user");
+});

--- a/tests/unit-js/user-profile-validation.test.mjs
+++ b/tests/unit-js/user-profile-validation.test.mjs
@@ -14,13 +14,17 @@ async function flushAsyncWork() {
     await new Promise(resolve => setTimeout(resolve, 0));
 }
 
-function createFetchRecorder() {
+function createFetchRecorder(overrides = {}) {
     const calls = [];
 
     return {
         calls,
         fetch: async (url, options = {}) => {
             calls.push({ url, options });
+            if (typeof overrides.fetch === "function") {
+                return overrides.fetch(url, options);
+            }
+
             return {
                 ok: true,
                 async json() {
@@ -41,7 +45,7 @@ function createFetchRecorder() {
     };
 }
 
-function bootstrapUserProfilePage() {
+function bootstrapUserProfilePage(overrides = {}) {
     const usernameForm = createElement({ tagName: "form", id: "username-form" });
     const usernameTitle = createElement({ tagName: "h3", classNames: ["profile-panel-title"], content: "Profile Data" });
     const usernameInput = createElement({ tagName: "input", id: "username", name: "username", value: "demo-user", classNames: ["settings-input", "auth-input"] });
@@ -83,7 +87,7 @@ function bootstrapUserProfilePage() {
         usernameForm,
         passwordForm
     ]);
-    const fetchRecorder = createFetchRecorder();
+    const fetchRecorder = createFetchRecorder(overrides);
     const context = {
         document,
         window: null,
@@ -210,4 +214,75 @@ test("blank username is blocked client-side and valid username submission succee
     assert.equal(runtime.usernameMessage.classList.contains("hidden"), false);
     assert.equal(runtime.usernameMessage.classList.contains("form-message--success"), true);
     assert.equal(runtime.usernameInput.value, "updated-user");
+});
+
+test("[ui-negative] forbidden 67-style usernames are blocked before the profile form submits", async () => {
+    const runtime = bootstrapUserProfilePage();
+
+    runtime.usernameInput.value = " 67 ";
+    const submitEvent = {
+        type: "submit",
+        target: runtime.usernameForm
+    };
+    runtime.usernameForm.dispatchEvent(submitEvent);
+    await flushAsyncWork();
+
+    assert.equal(runtime.fetchCalls.length, 0);
+    assert.equal(runtime.usernameInput.getAttribute("aria-invalid"), "true");
+    assert.equal(runtime.usernameError.textContent, "67 and six seven are not allowed here");
+    assert.equal(runtime.usernameMessage.classList.contains("form-message--error"), true);
+});
+
+test("[ui-negative] server-side username failures surface a visible profile error message", async () => {
+    const runtime = bootstrapUserProfilePage({
+        fetch: async () => ({
+            ok: false,
+            async json() {
+                return {
+                    message: "Username is already taken"
+                };
+            }
+        })
+    });
+
+    runtime.usernameInput.value = "taken-name";
+    runtime.usernameForm.dispatchEvent({
+        type: "submit",
+        target: runtime.usernameForm
+    });
+    await flushAsyncWork();
+
+    assert.equal(runtime.fetchCalls.length, 1);
+    assert.equal(runtime.usernameMessage.classList.contains("form-message--error"), true);
+    assert.equal(runtime.usernameMessage.textContent, "Username is already taken");
+});
+
+test("[ui-negative] server-side password failures keep the form visible and show an error", async () => {
+    const runtime = bootstrapUserProfilePage({
+        fetch: async (url) => ({
+            ok: false,
+            async json() {
+                return {
+                    message: url.includes("/password")
+                        ? "Current password is incorrect"
+                        : "Username update failed"
+                };
+            }
+        })
+    });
+
+    runtime.oldPasswordInput.value = "wrong-password";
+    runtime.newPasswordInput.value = "long-enough-password";
+    runtime.confirmNewPasswordInput.value = "long-enough-password";
+    runtime.passwordForm.dispatchEvent({
+        type: "submit",
+        target: runtime.passwordForm
+    });
+    await flushAsyncWork();
+
+    assert.equal(runtime.fetchCalls.length, 1);
+    assert.equal(runtime.passwordMessage.classList.contains("form-message--error"), true);
+    assert.equal(runtime.passwordMessage.textContent, "Current password is incorrect");
+    assert.equal(runtime.oldPasswordInput.value, "wrong-password");
+    assert.equal(runtime.newPasswordInput.value, "long-enough-password");
 });

--- a/tests/user/06-validation-execution-results.md
+++ b/tests/user/06-validation-execution-results.md
@@ -1,0 +1,42 @@
+# User Profile Validation Execution Results
+
+## Purpose
+
+Capture the current executable frontend validation coverage for the profile page without relying on full backend auth integration.
+
+## Source Surface
+
+- Template: [user.html](../../src/main/resources/templates/user.html)
+- Script: [user-settings.js](../../src/main/resources/static/js/user-settings.js)
+- Executable suite: [user-profile-validation.test.mjs](../unit-js/user-profile-validation.test.mjs)
+
+## User Story / Functional Slice
+
+As a user, I can distinguish profile and password sections, get client-side validation feedback, and only send valid profile/password requests.
+
+## Dependencies
+
+- `#username-form`
+- `#password-form`
+- `#username`
+- `#oldPassword`
+- `#newPassword`
+- `#confirmNewPassword`
+- field errors:
+  - `data-error-for="username"`
+  - `data-error-for="oldPassword"`
+  - `data-error-for="newPassword"`
+  - `data-error-for="confirmNewPassword"`
+
+## Execution Result
+
+- Executed locally with:
+  - `node --test tests/unit-js/user-profile-validation.test.mjs`
+- Result:
+  - `4/4` tests passed
+- Covered behaviors:
+  - separate `Profile Data` and `Change Password` sections are present
+  - confirm password mismatch is blocked client-side
+  - minimum password length validation is enforced at the frontend
+  - invalid fields surface error state
+  - valid username/password inputs pass frontend validation and reach mocked fetch calls

--- a/tests/user/README.md
+++ b/tests/user/README.md
@@ -28,6 +28,7 @@
 - password form
 - session API feedback and CSRF
 - JWT API parity notes
+- frontend validation execution results
 
 ## Related Shared Docs
 
@@ -56,6 +57,11 @@
   - password happy path and invalid current password path
   - CSRF/session contract checks
 
+## Executable Suites
+
+- [user-profile-validation.test.mjs](../unit-js/user-profile-validation.test.mjs): section presence, username validation, password confirm logic, minimum length, valid submit path with mocked fetch
+- [06-validation-execution-results.md](06-validation-execution-results.md): executed frontend validation result
+
 ## Plans
 
 - [01-page-shell-and-auth-guard.md](01-page-shell-and-auth-guard.md) — `WebMvc P0`
@@ -63,3 +69,4 @@
 - [03-password-form.md](03-password-form.md) — `Playwright` + `WebMvc API`
 - [04-session-api-feedback-and-csrf.md](04-session-api-feedback-and-csrf.md) — `WebMvc / integration P0`
 - [05-jwt-api-parity-notes.md](05-jwt-api-parity-notes.md) — `WebMvc JWT API P1`
+- [06-validation-execution-results.md](06-validation-execution-results.md) — executed JS frontend suite

--- a/tests/user/README.md
+++ b/tests/user/README.md
@@ -59,6 +59,8 @@
 
 ## Executable Suites
 
+- [UserRestControllerTest.java](../../src/test/java/com/example/telos/api/UserRestControllerTest.java): session API contract coverage for username/password endpoints, including `401`, `403`, validation, conflict, and business-rule errors
+- [UserJwtControllerTest.java](../../src/test/java/com/example/telos/api/UserJwtControllerTest.java): JWT API contract coverage for username/password/time-settings endpoints, including bearer-auth success and failure paths
 - [user-profile-validation.test.mjs](../unit-js/user-profile-validation.test.mjs): section presence, username validation, password confirm logic, minimum length, valid submit path with mocked fetch
 - [06-validation-execution-results.md](06-validation-execution-results.md): executed frontend validation result
 


### PR DESCRIPTION
Two issues flagged in review: the username form submit handler always emitted a hardcoded "Username cannot be empty" message regardless of the actual validation failure, and the JWT expiry test relied on `Thread.sleep` + a 1 ms TTL — inherently flaky under CI load.

## Changes

- **`user-settings.js`** – Submit handler now reads the message already written into the error element by `validateUsername()`, falling back to the hardcoded string only when the element is absent:
  ```js
  const validationMessage = usernameError?.textContent?.trim() || "Username cannot be empty";
  showMessage(usernameMessage, validationMessage, false);
  ```
  This surfaces the correct message (e.g. *"67 and six seven are not allowed here"*) instead of the generic fallback.

- **`JwtServiceTest.java`** – Replaced the `Thread.sleep(20)` + 1 ms expiry approach with a token built directly via JJWT with `issuedAt`/`expiration` set 10 s in the past — fully deterministic, zero wall-clock delay. Extracted a `buildKey(String secret)` helper to consolidate the repeated key-construction logic shared with `parseClaims`.